### PR TITLE
fix: release 1.3.1 parser and contact recovery

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "imessage",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "25 tools for exploring your iMessage history with AI",
   "author": {
     "name": "Ani Potts",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,56 @@
-name: CI
+name: ci
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - "hotfix/**"
+      - "codex/**"
   pull_request:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
+  test:
+    name: node ${{ matrix.node }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [18, 22]
+        node: [18, 22]
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
           cache: npm
-
       - run: npm ci
       - run: npm run build
       - run: npm run typecheck
       - run: npm test
+      - run: npm audit --audit-level=high
+
+  package-macos:
+    name: packed stdio on macos 14 arm64
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run test:packed-stdio
+      - run: npm pack --dry-run

--- a/.github/workflows/release-1.3.1.yml
+++ b/.github/workflows/release-1.3.1.yml
@@ -1,0 +1,145 @@
+name: release 1.3.1
+
+on:
+  push:
+    tags: [v1.3.1]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: verify release candidate
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+          cache: npm
+      - name: Match tag and package versions
+        run: >-
+          node -e 'const packageVersion=require("./package.json").version;
+          if (process.env.GITHUB_REF_NAME !== `v${packageVersion}`)
+          throw new Error("tag and package versions differ")'
+      - run: npm ci
+      - run: npm run build
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm audit --audit-level=high
+      - run: npm run test:packed-stdio
+      - run: npm pack --dry-run
+
+  publish-npm:
+    name: publish npm with provenance
+    needs: verify
+    runs-on: macos-14
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm publish --access public --provenance
+
+  verify-public-tarball:
+    name: verify public npm tarball
+    needs: publish-npm
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - name: Install and exercise the public package
+        env:
+          IMESSAGE_PACKAGE_SPEC: imessage-mcp@1.3.1
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if npm run test:packed-stdio; then
+              exit 0
+            fi
+            sleep 15
+          done
+          exit 1
+
+  github-release:
+    name: publish github release
+    needs: verify-public-tarball
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create v1.3.1
+          --verify-tag
+          --title "imessage-mcp 1.3.1"
+          --generate-notes
+
+  mcp-registry:
+    name: publish mcp registry metadata
+    needs: verify-public-tarball
+    runs-on: ubuntu-latest
+    environment: mcp-registry-release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - name: Install pinned MCP publisher
+        run: |
+          curl -fsSLo mcp-publisher.tar.gz https://github.com/modelcontextprotocol/registry/releases/download/v1.7.9/mcp-publisher_linux_amd64.tar.gz
+          echo "ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac  mcp-publisher.tar.gz" | sha256sum -c -
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+      - run: ./mcp-publisher login github-oidc
+      - run: ./mcp-publisher publish
+      - name: Verify registry version
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if curl -fsS "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.anipotts%2Fimessage-mcp" | jq -e '.servers[] | select((.server.name // .name) == "io.github.anipotts/imessage-mcp" and (.server.version // .version) == "1.3.1")' > /dev/null; then
+              exit 0
+            fi
+            sleep 15
+          done
+          exit 1
+
+  close-fixed-issues:
+    name: close verified issues
+    needs: [github-release, mcp-registry]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Close issue 5 after public verification
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "$(gh issue view 5 --repo anipotts/imessage-mcp --json state --jq .state)" = "OPEN" ]; then
+            gh issue close 5 --repo anipotts/imessage-mcp --comment "Fixed in imessage-mcp@1.3.1. The public npm tarball passed the attributed-body stdio reproduction before this issue was closed."
+          fi
+      - name: Close issue 6 after public verification
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "$(gh issue view 6 --repo anipotts/imessage-mcp --json state --jq .state)" = "OPEN" ]; then
+            gh issue close 6 --repo anipotts/imessage-mcp --comment "Fixed in imessage-mcp@1.3.1. Contact resolution now uses Apple's unified contacts, preserves collisions as candidates, and the public npm tarball passed its stdio gate before this issue was closed."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+# Keep this filename aligned with 2.x because npm permits one trusted publisher per package.
 name: release 1.3.1
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
     name: publish github release
     needs: verify-public-tarball
     runs-on: ubuntu-latest
+    environment: github-release
     permissions:
       contents: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
-          cache: npm
+          package-manager-cache: false
       - name: Match tag and package versions
         run: >-
           node -e 'const packageVersion=require("./package.json").version;
@@ -46,8 +46,14 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
-          cache: npm
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Verify trusted-publishing runtime
+        shell: bash
+        run: |
+          node -e "const [major, minor] = process.versions.node.split('.').map(Number); if (major < 22 || (major === 22 && minor < 14)) process.exit(1)"
+          NPM_VERSION=$(npm --version)
+          node -e "const [major, minor, patch] = process.argv[1].split('.').map(Number); if (major < 11 || (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))) process.exit(1)" "$NPM_VERSION"
       - run: npm ci
       - run: npm publish --access public --provenance
 
@@ -61,8 +67,8 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
-          cache: npm
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
       - run: npm ci
       - name: Install and exercise the public package
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.1] - 2026-08-10
+
+### Fixed
+- attributed-body messages now decode their complete Foundation string without binary prefixes or truncation
+- contact lookup now uses Apple's unified Contacts view instead of format-dependent per-source database order
+- shared handles return structured ambiguity candidates instead of silently selecting a contact
+- empty contact queries are rejected before they can match every handle
+- the Claude plugin validates again and no longer runs a database probe during installation
+
+### Changed
+- patched runtime dependencies while retaining the 1.x Node.js 18 compatibility floor
+- added Foundation-generated parser fixtures and deterministic contact-collision coverage
+
 ## [1.3.0] - 2026-02-25
 
 ### Added

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,9 +1,0 @@
-{
-  "hooks": [
-    {
-      "event": "PostInstall",
-      "command": "npx imessage-mcp doctor --json",
-      "description": "Verify iMessage database access after plugin install"
-    }
-  ]
-}

--- a/native/contact-resolver.js
+++ b/native/contact-resolver.js
@@ -1,0 +1,96 @@
+ObjC.import("Contacts");
+
+const MAX_CONTACTS = 50000;
+
+function stringValue(value) {
+  if (!value) return "";
+  const unwrapped = ObjC.unwrap(value);
+  return unwrapped === undefined || unwrapped === null ? "" : String(unwrapped).trim();
+}
+
+function valuesFromMultiValue(items, transform) {
+  const values = [];
+  const count = Number(items.count);
+  for (let index = 0; index < count; index += 1) {
+    const value = transform(items.objectAtIndex(index).value);
+    if (value) values.push(value);
+  }
+  return values;
+}
+
+function run() {
+  const authorization = Number(
+    $.CNContactStore.authorizationStatusForEntityType($.CNEntityTypeContacts),
+  );
+  if (authorization !== 3) {
+    return JSON.stringify({
+      status: "unavailable",
+      reason: authorization === 0 ? "permission_not_determined" : "permission_denied",
+    });
+  }
+
+  try {
+    const keys = $.NSMutableArray.alloc.init;
+    keys.addObject($.CNContactIdentifierKey);
+    keys.addObject(
+      $.CNContactFormatter.descriptorForRequiredKeysForStyle(
+        $.CNContactFormatterStyleFullName,
+      ),
+    );
+    keys.addObject($.CNContactOrganizationNameKey);
+    keys.addObject($.CNContactNicknameKey);
+    keys.addObject($.CNContactPhoneNumbersKey);
+    keys.addObject($.CNContactEmailAddressesKey);
+
+    const request = $.CNContactFetchRequest.alloc.initWithKeysToFetch(keys);
+    request.unifyResults = true;
+
+    const contacts = [];
+    let limitExceeded = false;
+    const error = Ref();
+    const store = $.CNContactStore.alloc.init;
+    const ok = store.enumerateContactsWithFetchRequestErrorUsingBlock(
+      request,
+      error,
+      (contact, stop) => {
+        if (contacts.length >= MAX_CONTACTS) {
+          limitExceeded = true;
+          stop[0] = true;
+          return;
+        }
+
+        const formatted = $.CNContactFormatter.stringFromContactStyle(
+          contact,
+          $.CNContactFormatterStyleFullName,
+        );
+        const name = stringValue(formatted)
+          || stringValue(contact.organizationName)
+          || stringValue(contact.nickname);
+
+        contacts.push({
+          identifier: stringValue(contact.identifier),
+          name,
+          phones: valuesFromMultiValue(
+            contact.phoneNumbers,
+            (value) => stringValue(value.stringValue),
+          ),
+          emails: valuesFromMultiValue(
+            contact.emailAddresses,
+            (value) => stringValue(value),
+          ),
+        });
+      },
+    );
+
+    if (!ok) {
+      return JSON.stringify({ status: "unavailable", reason: "contacts_query_failed" });
+    }
+    if (limitExceeded) {
+      return JSON.stringify({ status: "unavailable", reason: "contact_limit_exceeded" });
+    }
+
+    return JSON.stringify({ status: "ok", contacts });
+  } catch (_error) {
+    return JSON.stringify({ status: "unavailable", reason: "contacts_query_failed" });
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,37 +1,38 @@
 {
   "name": "imessage-mcp",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imessage-mcp",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.0",
-        "better-sqlite3": "^12.6.2",
-        "zod": "^3.25.67"
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "better-sqlite3": "^11.10.0",
+        "zod": "^3.25.76"
       },
       "bin": {
         "imessage-mcp": "bin/imessage-mcp.js"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
-        "@types/node": "^20.0.0",
-        "playwright": "^1.58.2",
-        "tsx": "^4.21.0",
-        "typescript": "^5.7.0",
-        "vitest": "^4.0.18"
+        "@types/node": "^20.19.43",
+        "playwright": "1.58.2",
+        "tsx": "^4.23.12",
+        "typescript": "^5.9.3",
+        "vite": "6.4.3",
+        "vitest": "^3.2.7"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
       "cpu": [
         "ppc64"
       ],
@@ -46,9 +47,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
       "cpu": [
         "arm"
       ],
@@ -63,9 +64,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
       "cpu": [
         "arm64"
       ],
@@ -80,9 +81,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
       "cpu": [
         "x64"
       ],
@@ -97,9 +98,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
       "cpu": [
         "arm64"
       ],
@@ -114,9 +115,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
       "cpu": [
         "x64"
       ],
@@ -131,9 +132,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
       "cpu": [
         "arm64"
       ],
@@ -148,9 +149,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
       "cpu": [
         "x64"
       ],
@@ -165,9 +166,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
       "cpu": [
         "arm"
       ],
@@ -182,9 +183,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
       "cpu": [
         "arm64"
       ],
@@ -199,9 +200,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
       "cpu": [
         "ia32"
       ],
@@ -216,9 +217,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
       "cpu": [
         "loong64"
       ],
@@ -233,9 +234,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
       "cpu": [
         "mips64el"
       ],
@@ -250,9 +251,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
       "cpu": [
         "ppc64"
       ],
@@ -267,9 +268,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
       "cpu": [
         "riscv64"
       ],
@@ -284,9 +285,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
       "cpu": [
         "s390x"
       ],
@@ -301,9 +302,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
       "cpu": [
         "x64"
       ],
@@ -318,9 +319,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
       "cpu": [
         "arm64"
       ],
@@ -335,9 +336,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
       "cpu": [
         "x64"
       ],
@@ -352,9 +353,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
       "cpu": [
         "arm64"
       ],
@@ -369,9 +370,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
       "cpu": [
         "x64"
       ],
@@ -386,9 +387,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
       "cpu": [
         "arm64"
       ],
@@ -403,9 +404,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
       "cpu": [
         "x64"
       ],
@@ -420,9 +421,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
       "cpu": [
         "arm64"
       ],
@@ -437,9 +438,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
       "cpu": [
         "ia32"
       ],
@@ -454,9 +455,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
       "cpu": [
         "x64"
       ],
@@ -470,18 +471,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -490,12 +479,12 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -529,10 +518,39 @@
         }
       }
     },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
       "cpu": [
         "arm"
       ],
@@ -544,9 +562,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
       "cpu": [
         "arm64"
       ],
@@ -558,9 +576,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
       "cpu": [
         "arm64"
       ],
@@ -572,9 +590,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
       "cpu": [
         "x64"
       ],
@@ -586,9 +604,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
       "cpu": [
         "arm64"
       ],
@@ -600,9 +618,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
       "cpu": [
         "x64"
       ],
@@ -614,9 +632,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
       "cpu": [
         "arm"
       ],
@@ -628,9 +646,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
       "cpu": [
         "arm"
       ],
@@ -642,9 +660,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
       "cpu": [
         "arm64"
       ],
@@ -656,9 +674,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
       "cpu": [
         "arm64"
       ],
@@ -670,9 +688,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
       "cpu": [
         "loong64"
       ],
@@ -684,9 +702,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
       "cpu": [
         "loong64"
       ],
@@ -698,9 +716,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
       "cpu": [
         "ppc64"
       ],
@@ -712,9 +730,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
       "cpu": [
         "ppc64"
       ],
@@ -726,9 +744,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
       "cpu": [
         "riscv64"
       ],
@@ -740,9 +758,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
       "cpu": [
         "riscv64"
       ],
@@ -754,9 +772,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
       "cpu": [
         "s390x"
       ],
@@ -768,9 +786,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
       "cpu": [
         "x64"
       ],
@@ -782,9 +800,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
       "cpu": [
         "x64"
       ],
@@ -796,9 +814,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
       "cpu": [
         "x64"
       ],
@@ -810,9 +828,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
       "cpu": [
         "arm64"
       ],
@@ -824,9 +842,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
       "cpu": [
         "arm64"
       ],
@@ -838,9 +856,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
       "cpu": [
         "ia32"
       ],
@@ -852,9 +870,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
       "cpu": [
         "x64"
       ],
@@ -866,9 +884,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
       "cpu": [
         "x64"
       ],
@@ -878,13 +896,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -915,16 +926,16 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -932,40 +943,39 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
+        "magic-string": "^0.30.17"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -977,41 +987,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
-        "pathe": "^2.0.3"
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "magic-string": "^0.30.21",
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1019,24 +1030,28 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1056,9 +1071,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1119,17 +1134,14 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
     "node_modules/bindings": {
@@ -1153,21 +1165,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1209,6 +1234,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1239,13 +1274,30 @@
       }
     },
     "node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -1255,9 +1307,9 @@
       "license": "ISC"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1357,6 +1409,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -1448,9 +1510,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1460,9 +1522,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1473,32 +1535,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/escape-html": {
@@ -1539,9 +1601,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -1557,9 +1619,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1571,7 +1633,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1611,12 +1672,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1635,9 +1697,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1720,9 +1782,9 @@
       "license": "MIT"
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1780,19 +1842,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -1824,9 +1873,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1836,11 +1885,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
-      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1866,9 +1914,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -1914,9 +1962,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1944,13 +1992,20 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -1963,6 +2018,13 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1984,12 +2046,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -2063,9 +2129,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2097,9 +2163,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -2128,17 +2194,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/sxzz",
-        "https://opencollective.com/debug"
-      ],
-      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -2180,9 +2235,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2196,6 +2251,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2204,12 +2269,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2258,25 +2322,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2294,7 +2343,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2343,9 +2392,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -2353,12 +2402,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2368,12 +2418,16 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -2429,24 +2483,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/rollup": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2456,31 +2500,32 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.59.0",
-        "@rollup/rollup-android-arm64": "4.59.0",
-        "@rollup/rollup-darwin-arm64": "4.59.0",
-        "@rollup/rollup-darwin-x64": "4.59.0",
-        "@rollup/rollup-freebsd-arm64": "4.59.0",
-        "@rollup/rollup-freebsd-x64": "4.59.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
-        "@rollup/rollup-linux-arm64-musl": "4.59.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
-        "@rollup/rollup-linux-loong64-musl": "4.59.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
-        "@rollup/rollup-linux-x64-musl": "4.59.0",
-        "@rollup/rollup-openbsd-x64": "4.59.0",
-        "@rollup/rollup-openharmony-arm64": "4.59.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
-        "@rollup/rollup-win32-x64-gnu": "4.59.0",
-        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -2527,9 +2572,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2611,14 +2656,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2630,13 +2675,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2785,10 +2830,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -2821,24 +2879,21 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2847,10 +2902,30 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2867,15 +2942,13 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -2885,6 +2958,21 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/tunnel-agent": {
@@ -2900,17 +2988,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -2959,25 +3064,24 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -2986,14 +3090,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
         "jiti": ">=1.21.0",
-        "less": "^4.0.0",
+        "less": "*",
         "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -3034,51 +3138,574 @@
         }
       }
     },
-    "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
         "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -3086,19 +3713,13 @@
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@opentelemetry/api": {
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
+        "@vitest/browser": {
           "optional": true
         },
         "@vitest/ui": {
@@ -3155,18 +3776,17 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imessage-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "mcpName": "io.github.anipotts/imessage-mcp",
   "description": "iMessage MCP server — 25 tools for searching, analyzing, and exploring your entire iMessage history on macOS",
   "author": "Ani Potts",
@@ -25,21 +25,27 @@
     "dump": "tsx src/commands/dump.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:packed-stdio": "node scripts/test-packed-stdio.mjs",
+    "verify:local-parity": "tsx scripts/verify-local-parity.ts",
     "test:watch": "vitest",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.0",
-    "better-sqlite3": "^12.6.2",
-    "zod": "^3.25.67"
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "better-sqlite3": "^11.10.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
-    "@types/node": "^20.0.0",
-    "playwright": "^1.58.2",
-    "tsx": "^4.21.0",
-    "typescript": "^5.7.0",
-    "vitest": "^4.0.18"
+    "@types/node": "^20.19.43",
+    "playwright": "1.58.2",
+    "tsx": "^4.23.12",
+    "typescript": "^5.9.3",
+    "vite": "6.4.3",
+    "vitest": "^3.2.7"
+  },
+  "overrides": {
+    "@hono/node-server": "1.19.13"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "files": [
     "dist",
     "bin",
+    "native",
     "README.md",
     "LICENSE",
     "server.json"

--- a/scripts/foundation-decode.js
+++ b/scripts/foundation-decode.js
@@ -1,0 +1,53 @@
+ObjC.import("Foundation");
+
+const MAX_BLOBS = 500;
+const MAX_TOTAL_BYTES = 8 * 1024 * 1024;
+
+function run() {
+  try {
+    const inputData = $.NSFileHandle.fileHandleWithStandardInput.readDataToEndOfFile;
+    const inputString = $.NSString.alloc.initWithDataEncoding(
+      inputData,
+      $.NSUTF8StringEncoding,
+    );
+    const request = JSON.parse(String(ObjC.unwrap(inputString)));
+    if (!Array.isArray(request.blobs) || request.blobs.length > MAX_BLOBS) {
+      return JSON.stringify({ status: "invalid_input" });
+    }
+
+    let totalBytes = 0;
+    const results = [];
+    for (const encoded of request.blobs) {
+      if (typeof encoded !== "string") {
+        results.push({ status: "malformed" });
+        continue;
+      }
+
+      const data = $.NSData.alloc.initWithBase64EncodedStringOptions(encoded, 0);
+      if (!data) {
+        results.push({ status: "malformed" });
+        continue;
+      }
+      totalBytes += Number(data.length);
+      if (totalBytes > MAX_TOTAL_BYTES) {
+        return JSON.stringify({ status: "invalid_input" });
+      }
+
+      try {
+        const value = $.NSUnarchiver.unarchiveObjectWithData(data);
+        const text = value && value.string ? ObjC.unwrap(value.string) : null;
+        results.push(
+          typeof text === "string"
+            ? { status: "decoded", text }
+            : { status: "unsupported" },
+        );
+      } catch (_error) {
+        results.push({ status: "malformed" });
+      }
+    }
+
+    return JSON.stringify({ status: "ok", results });
+  } catch (_error) {
+    return JSON.stringify({ status: "invalid_input" });
+  }
+}

--- a/scripts/test-packed-stdio.mjs
+++ b/scripts/test-packed-stdio.mjs
@@ -1,0 +1,150 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import Database from "better-sqlite3";
+
+const ISSUE_TEXT = "Hey Jordan, can you call me back at 555-0173 when you get a chance? Wanted to talk through the weekend plans before I book anything.";
+const ISSUE_BLOB_BASE64 = "BAtzdHJlYW10eXBlZIHoA4QBQISEhBJOU0F0dHJpYnV0ZWRTdHJpbmcAhIQITlNPYmplY3QAhZKEhIQITlNTdHJpbmcBlIQBK4GEAEhleSBKb3JkYW4sIGNhbiB5b3UgY2FsbCBtZSBiYWNrIGF0IDU1NS0wMTczIHdoZW4geW91IGdldCBhIGNoYW5jZT8gV2FudGVkIHRvIHRhbGsgdGhyb3VnaCB0aGUgd2Vla2VuZCBwbGFucyBiZWZvcmUgSSBib29rIGFueXRoaW5nLoaEAmlJAYGEAJKEhIQMTlNEaWN0aW9uYXJ5AJSEAWkAhoY=";
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+
+function createSyntheticDatabase(databasePath) {
+  const database = new Database(databasePath);
+  database.exec(`
+    CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT NOT NULL);
+    CREATE TABLE chat (
+      ROWID INTEGER PRIMARY KEY,
+      display_name TEXT,
+      chat_identifier TEXT NOT NULL
+    );
+    CREATE TABLE message (
+      ROWID INTEGER PRIMARY KEY,
+      text TEXT,
+      attributedBody BLOB,
+      is_from_me INTEGER NOT NULL,
+      date INTEGER NOT NULL,
+      handle_id INTEGER,
+      associated_message_type INTEGER NOT NULL DEFAULT 0,
+      cache_has_attachments INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE chat_message_join (chat_id INTEGER NOT NULL, message_id INTEGER NOT NULL);
+    CREATE TABLE chat_handle_join (chat_id INTEGER NOT NULL, handle_id INTEGER NOT NULL);
+  `);
+  database.prepare("INSERT INTO handle (ROWID, id) VALUES (1, ?)").run("+15555550100");
+  database.prepare("INSERT INTO chat (ROWID, display_name, chat_identifier) VALUES (1, NULL, ?)").run("synthetic-chat");
+  database.prepare(`
+    INSERT INTO message (
+      ROWID, text, attributedBody, is_from_me, date, handle_id,
+      associated_message_type, cache_has_attachments
+    ) VALUES (1, NULL, ?, 0, 1, 1, 0, 0)
+  `).run(Buffer.from(ISSUE_BLOB_BASE64, "base64"));
+  database.prepare("INSERT INTO chat_message_join (chat_id, message_id) VALUES (1, 1)").run();
+  database.prepare("INSERT INTO chat_handle_join (chat_id, handle_id) VALUES (1, 1)").run();
+  database.close();
+}
+
+function textContent(result) {
+  const block = result.content?.find((item) => item.type === "text");
+  return block?.text ?? "";
+}
+
+const temporaryRoot = mkdtempSync(join(tmpdir(), "imessage-mcp-1.3.1-"));
+let client;
+
+try {
+  const projectRoot = resolve(scriptDirectory, "..");
+  const expectedPackage = JSON.parse(readFileSync(join(projectRoot, "package.json"), "utf8"));
+  let packageSpec = process.env.IMESSAGE_PACKAGE_SPEC;
+  if (!packageSpec) {
+    const packOutput = JSON.parse(execFileSync(
+      "npm",
+      ["pack", "--json", "--pack-destination", temporaryRoot],
+      { cwd: projectRoot, encoding: "utf8" },
+    ));
+    packageSpec = join(temporaryRoot, packOutput[0].filename);
+  }
+  const installRoot = join(temporaryRoot, "install");
+  execFileSync(
+    "npm",
+    ["install", "--no-audit", "--no-fund", "--prefix", installRoot, packageSpec],
+    { stdio: "ignore" },
+  );
+
+  const installedPackage = JSON.parse(readFileSync(
+    join(installRoot, "node_modules", "imessage-mcp", "package.json"),
+    "utf8",
+  ));
+  if (installedPackage.version !== expectedPackage.version) {
+    throw new Error(`expected package version ${expectedPackage.version}, received ${installedPackage.version}`);
+  }
+
+  const databasePath = join(temporaryRoot, "chat.db");
+  createSyntheticDatabase(databasePath);
+
+  const command = process.execPath;
+  const serverEntry = join(
+    installRoot,
+    "node_modules",
+    "imessage-mcp",
+    "bin",
+    "imessage-mcp.js",
+  );
+  const transport = new StdioClientTransport({
+    command,
+    args: [serverEntry],
+    env: {
+      ...Object.fromEntries(Object.entries(process.env).filter(([, value]) => value !== undefined)),
+      IMESSAGE_DB: databasePath,
+    },
+    stderr: "pipe",
+  });
+  client = new Client({ name: "packed-stdio-gate", version: "1.0.0" });
+  await client.connect(transport);
+
+  const tools = await client.listTools();
+  if (!tools.tools.some((tool) => tool.name === "search_messages")) {
+    throw new Error("packed server did not expose search_messages");
+  }
+
+  const search = await client.callTool({
+    name: "search_messages",
+    arguments: {
+      query: "weekend plans",
+      include_all: true,
+      limit: 10,
+    },
+  });
+  const searchText = textContent(search);
+  if (!searchText.includes(ISSUE_TEXT) || searchText.includes("�")) {
+    throw new Error("packed stdio server did not return the complete attributed body");
+  }
+
+  let rejectedEmptyQuery = false;
+  try {
+    const emptyQuery = await client.callTool({
+      name: "resolve_contact",
+      arguments: { query: "   " },
+    });
+    rejectedEmptyQuery = emptyQuery.isError === true;
+  } catch {
+    rejectedEmptyQuery = true;
+  }
+  if (!rejectedEmptyQuery) {
+    throw new Error("packed stdio server accepted an empty contact query");
+  }
+
+  console.log(JSON.stringify({
+    status: "pass",
+    source: process.env.IMESSAGE_PACKAGE_SPEC ? "registry" : "local_tarball",
+    package_version: installedPackage.version,
+    tools: tools.tools.length,
+    attributed_body: "exact",
+    empty_contact_query: "rejected",
+  }));
+} finally {
+  if (client) await client.close().catch(() => undefined);
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}

--- a/scripts/verify-local-parity.ts
+++ b/scripts/verify-local-parity.ts
@@ -1,0 +1,221 @@
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  getAddressBookStatus,
+  lookupContact,
+  resolveContact,
+} from "../src/contacts.js";
+import {
+  extractTextFromAttributedBody,
+  openReadonlyDatabase,
+} from "../src/db.js";
+
+const MAX_BLOBS = 500;
+const MAX_TOTAL_BYTES = 8 * 1024 * 1024;
+const MAX_HANDLES = 200;
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const decoderScript = join(projectRoot, "scripts", "foundation-decode.js");
+const databasePath = process.env.IMESSAGE_DB
+  || join(homedir(), "Library", "Messages", "chat.db");
+
+interface BlobRow {
+  rowid: number;
+  attributedBody: Buffer;
+}
+
+interface NativeDecodeResult {
+  status: string;
+  text?: string;
+}
+
+function selectAttributedBodies(): BlobRow[] {
+  const database = openReadonlyDatabase(databasePath);
+  try {
+    const total = Number((database.prepare(`
+      SELECT COUNT(*) AS count
+      FROM message
+      WHERE text IS NULL
+        AND attributedBody IS NOT NULL
+        AND associated_message_type = 0
+        AND length(attributedBody) <= 1048576
+    `).get() as { count: number }).count);
+    if (total === 0) return [];
+
+    const width = Math.min(100, total);
+    const offsets = [...new Set([
+      0,
+      Math.max(0, Math.floor(total * 0.25) - Math.floor(width / 2)),
+      Math.max(0, Math.floor(total * 0.5) - Math.floor(width / 2)),
+      Math.max(0, Math.floor(total * 0.75) - Math.floor(width / 2)),
+      Math.max(0, total - width),
+    ])];
+    const statement = database.prepare(`
+      SELECT ROWID AS rowid, attributedBody
+      FROM message
+      WHERE text IS NULL
+        AND attributedBody IS NOT NULL
+        AND associated_message_type = 0
+        AND length(attributedBody) <= 1048576
+      ORDER BY ROWID ASC
+      LIMIT @limit OFFSET @offset
+    `);
+
+    const selected = new Map<number, BlobRow>();
+    let bytes = 0;
+    for (const offset of offsets) {
+      const rows = statement.all({ limit: width, offset }) as BlobRow[];
+      for (const row of rows) {
+        if (selected.has(row.rowid)) continue;
+        if (selected.size >= MAX_BLOBS || bytes + row.attributedBody.length > MAX_TOTAL_BYTES) {
+          return [...selected.values()];
+        }
+        selected.set(row.rowid, row);
+        bytes += row.attributedBody.length;
+      }
+    }
+    return [...selected.values()];
+  } finally {
+    database.close();
+  }
+}
+
+function decodeWithFoundation(rows: BlobRow[]): NativeDecodeResult[] {
+  const raw = execFileSync(
+    "/usr/bin/osascript",
+    ["-l", "JavaScript", decoderScript],
+    {
+      input: JSON.stringify({
+        blobs: rows.map((row) => row.attributedBody.toString("base64")),
+      }),
+      encoding: "utf8",
+      timeout: 30_000,
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ["pipe", "pipe", "ignore"],
+    },
+  );
+  const response = JSON.parse(raw) as {
+    status: string;
+    results?: NativeDecodeResult[];
+  };
+  if (response.status !== "ok" || !Array.isArray(response.results)) {
+    throw new Error("native_decoder_failed");
+  }
+  return response.results;
+}
+
+function selectHandles(): string[] {
+  const database = openReadonlyDatabase(databasePath);
+  try {
+    return (database.prepare(`
+      SELECT h.id
+      FROM handle h
+      JOIN message m ON m.handle_id = h.ROWID
+      WHERE h.id IS NOT NULL AND trim(h.id) <> ''
+      GROUP BY h.id
+      ORDER BY MIN(m.ROWID) ASC
+      LIMIT @limit
+    `).all({ limit: MAX_HANDLES }) as Array<{ id: string }>).map((row) => row.id);
+  } finally {
+    database.close();
+  }
+}
+
+function fail(reason: string, evidence: Record<string, unknown> = {}): never {
+  console.log(JSON.stringify({ status: "fail", reason, ...evidence }));
+  process.exit(1);
+}
+
+try {
+  const rows = selectAttributedBodies();
+  if (rows.length === 0) fail("no_attributed_bodies");
+  const decoded = decodeWithFoundation(rows);
+
+  let nativeDecoded = 0;
+  let nativeSkipped = 0;
+  let parserMatches = 0;
+  let parserMismatches = 0;
+  for (let index = 0; index < rows.length; index += 1) {
+    const native = decoded[index];
+    if (native?.status !== "decoded" || typeof native.text !== "string") {
+      nativeSkipped += 1;
+      continue;
+    }
+    nativeDecoded += 1;
+    const expected = native.text.trim() || null;
+    const actual = extractTextFromAttributedBody(rows[index].attributedBody);
+    if (actual === expected) parserMatches += 1;
+    else parserMismatches += 1;
+  }
+
+  const addressBook = getAddressBookStatus();
+  if (!addressBook.available) fail("contacts_unavailable");
+  const handles = selectHandles();
+  if (handles.length === 0) fail("no_message_handles");
+
+  let unique = 0;
+  let ambiguous = 0;
+  let notFound = 0;
+  let contactMismatches = 0;
+  for (const handle of handles) {
+    const resolution = resolveContact(handle);
+    const lookup = lookupContact(handle);
+    if (resolution.status === "unique") {
+      unique += 1;
+      if (lookup.tier !== "known" || lookup.name !== resolution.candidate.name) {
+        contactMismatches += 1;
+      }
+    } else if (resolution.status === "ambiguous") {
+      ambiguous += 1;
+      if (lookup.tier !== "unknown" || lookup.name !== handle.trim()) {
+        contactMismatches += 1;
+      }
+    } else if (resolution.status === "not_found") {
+      notFound += 1;
+      if (lookup.tier !== "unknown") contactMismatches += 1;
+    } else {
+      contactMismatches += 1;
+    }
+  }
+
+  if (nativeDecoded === 0 || parserMismatches > 0 || contactMismatches > 0) {
+    fail("parity_mismatch", {
+      parser: {
+        selected: rows.length,
+        native_decoded: nativeDecoded,
+        native_skipped: nativeSkipped,
+        matches: parserMatches,
+        mismatches: parserMismatches,
+      },
+      contacts: {
+        selected: handles.length,
+        unique,
+        ambiguous,
+        not_found: notFound,
+        mismatches: contactMismatches,
+      },
+    });
+  }
+
+  console.log(JSON.stringify({
+    status: "pass",
+    parser: {
+      selected: rows.length,
+      native_decoded: nativeDecoded,
+      native_skipped: nativeSkipped,
+      matches: parserMatches,
+      mismatches: 0,
+    },
+    contacts: {
+      selected: handles.length,
+      unique,
+      ambiguous,
+      not_found: notFound,
+      mismatches: 0,
+    },
+    emitted_private_values: 0,
+  }));
+} catch (_error) {
+  fail("verification_failed");
+}

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/anipotts/imessage-mcp",
     "source": "github"
   },
-  "version": "1.3.0",
+  "version": "1.3.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "imessage-mcp",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -85,22 +85,21 @@ async function runChecks(): Promise<Check[]> {
   }
 
   // 6. AddressBook
-  const { getAddressBookSources, loadAddressBook } = await import("../contacts.js");
-  const sources = getAddressBookSources();
-  if (sources.length > 0) {
-    const contacts = loadAddressBook();
+  const { getAddressBookStatus } = await import("../contacts.js");
+  const contacts = getAddressBookStatus();
+  if (contacts.available) {
     checks.push({
       name: "AddressBook",
-      status: contacts.size > 0 ? "pass" : "warn",
-      detail: contacts.size > 0
-        ? `${contacts.size} contacts resolved from macOS AddressBook`
-        : "AddressBook databases found but no contacts loaded",
+      status: contacts.contactCount > 0 ? "pass" : "warn",
+      detail: contacts.contactCount > 0
+        ? `${contacts.contactCount} unified contacts available from macOS Contacts`
+        : "macOS Contacts is available but contains no contacts with handles",
     });
   } else {
     checks.push({
       name: "AddressBook",
       status: "warn",
-      detail: "No AddressBook databases found — contact names won't be resolved. This is optional.",
+      detail: "macOS Contacts is unavailable — contact names will use raw handles. Allow Contacts access for your MCP client if you want names.",
     });
   }
 

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -1,12 +1,13 @@
-// Contact resolution -- macOS AddressBook auto-resolve
+// Contact resolution through macOS Contacts.framework.
 //
-// No hardcoded contacts. Queries the local AddressBook SQLite databases
-// to resolve phone numbers and emails to real names.
+// Contacts.framework performs Apple's linked-card and preferred-name resolution
+// before records reach this process. Distinct unified contacts that share a
+// handle remain distinct candidates and are never collapsed by scan order.
 
 import { execFileSync } from "node:child_process";
-import { homedir } from "node:os";
-import path from "node:path";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export type ContactTier = "known" | "unknown";
 
@@ -16,142 +17,317 @@ export interface Contact {
   tier: ContactTier;
 }
 
-// macOS AddressBook auto-resolve cache
-// Loaded once on first lookup, maps normalized digits/emails -> name
-let addressBookCache: Map<string, string> | null = null;
+export interface UnifiedContactRecord {
+  identifier: string;
+  name: string;
+  phones: string[];
+  emails: string[];
+}
 
-export function getAddressBookSources(): string[] {
-  const sourcesDir = path.join(
-    homedir(),
-    "Library",
-    "Application Support",
-    "AddressBook",
-    "Sources",
-  );
-  if (!existsSync(sourcesDir)) return [];
+export interface ContactCandidate {
+  name: string;
+  handles: string[];
+}
+
+export type ContactResolution =
+  | { status: "unique"; candidate: ContactCandidate }
+  | { status: "ambiguous"; candidates: ContactCandidate[] }
+  | { status: "not_found" }
+  | { status: "unavailable"; reason: string };
+
+interface NativeContactSuccess {
+  status: "ok";
+  contacts: UnifiedContactRecord[];
+}
+
+interface NativeContactUnavailable {
+  status: "unavailable";
+  reason: string;
+}
+
+type NativeContactResult = NativeContactSuccess | NativeContactUnavailable;
+type ContactLoader = () => NativeContactResult;
+
+interface IndexedHandle {
+  raw: string;
+  key: string;
+  searchKey: string;
+}
+
+interface IndexedContact {
+  identifier: string;
+  name: string;
+  nameKey: string;
+  handles: IndexedHandle[];
+}
+
+const CONTACT_RESOLVER_SCRIPT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../native/contact-resolver.js",
+);
+const MAX_NATIVE_OUTPUT_BYTES = 32 * 1024 * 1024;
+const MAX_NATIVE_CONTACTS = 50_000;
+
+function cleanString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function normalizeContactName(value: string): string {
+  return value.normalize("NFKC").trim().replace(/\s+/gu, " ").toLocaleLowerCase("en-US");
+}
+
+export function normalizeContactHandle(value: string): { key: string; searchKey: string } | null {
+  const cleaned = value.normalize("NFKC").trim();
+  if (!cleaned) return null;
+
+  if (cleaned.includes("@")) {
+    const email = cleaned.toLocaleLowerCase("en-US");
+    return { key: `email:${email}`, searchKey: email };
+  }
+
+  const digits = cleaned.replace(/\D/gu, "");
+  if (digits.length > 0) {
+    const canonicalDigits = digits.length >= 10 ? digits.slice(-10) : digits;
+    return { key: `phone:${canonicalDigits}`, searchKey: canonicalDigits };
+  }
+
+  const other = cleaned.toLocaleLowerCase("en-US");
+  return { key: `other:${other}`, searchKey: other };
+}
+
+function parseNativeResult(raw: string): NativeContactResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { status: "unavailable", reason: "invalid_native_response" };
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return { status: "unavailable", reason: "invalid_native_response" };
+  }
+
+  const value = parsed as Record<string, unknown>;
+  if (value.status === "unavailable") {
+    return {
+      status: "unavailable",
+      reason: cleanString(value.reason) || "contacts_unavailable",
+    };
+  }
+  if (value.status !== "ok" || !Array.isArray(value.contacts)) {
+    return { status: "unavailable", reason: "invalid_native_response" };
+  }
+  if (value.contacts.length > MAX_NATIVE_CONTACTS) {
+    return { status: "unavailable", reason: "contact_limit_exceeded" };
+  }
+
+  const contacts: UnifiedContactRecord[] = [];
+  for (const candidate of value.contacts) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const row = candidate as Record<string, unknown>;
+    const identifier = cleanString(row.identifier);
+    if (!identifier) continue;
+
+    contacts.push({
+      identifier,
+      name: cleanString(row.name),
+      phones: Array.isArray(row.phones)
+        ? row.phones.map(cleanString).filter(Boolean)
+        : [],
+      emails: Array.isArray(row.emails)
+        ? row.emails.map(cleanString).filter(Boolean)
+        : [],
+    });
+  }
+
+  return { status: "ok", contacts };
+}
+
+function loadNativeContacts(): NativeContactResult {
+  if (process.platform !== "darwin" || !existsSync(CONTACT_RESOLVER_SCRIPT)) {
+    return { status: "unavailable", reason: "contacts_unavailable" };
+  }
 
   try {
-    const entries = readdirSync(sourcesDir);
-    return entries
-      .map((e) => path.join(sourcesDir, e, "AddressBook-v22.abcddb"))
-      .filter((p) => existsSync(p));
+    const raw = execFileSync(
+      "/usr/bin/osascript",
+      ["-l", "JavaScript", CONTACT_RESOLVER_SCRIPT],
+      {
+        encoding: "utf8",
+        timeout: 15_000,
+        maxBuffer: MAX_NATIVE_OUTPUT_BYTES,
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+    return parseNativeResult(raw);
   } catch {
-    return [];
+    return { status: "unavailable", reason: "contacts_query_failed" };
   }
+}
+
+function compareIndexedContacts(left: IndexedContact, right: IndexedContact): number {
+  const byName = left.nameKey.localeCompare(right.nameKey, "en-US");
+  if (byName !== 0) return byName;
+  return left.identifier.localeCompare(right.identifier, "en-US");
+}
+
+function publicCandidate(contact: IndexedContact): ContactCandidate {
+  return {
+    name: contact.name,
+    handles: contact.handles.map((handle) => handle.raw),
+  };
+}
+
+export class UnifiedContactResolver {
+  private loaded = false;
+  private unavailableReason: string | null = null;
+  private contacts: IndexedContact[] = [];
+  private byHandle = new Map<string, IndexedContact[]>();
+
+  constructor(private readonly loader: ContactLoader = loadNativeContacts) {}
+
+  private ensureLoaded(): void {
+    if (this.loaded) return;
+    this.loaded = true;
+
+    const result = this.loader();
+    if (result.status === "unavailable") {
+      this.unavailableReason = result.reason;
+      return;
+    }
+
+    const byIdentifier = new Map<string, IndexedContact>();
+    for (const record of result.contacts) {
+      const handlesByKey = new Map<string, IndexedHandle>();
+      for (const raw of [...record.phones, ...record.emails]) {
+        const normalized = normalizeContactHandle(raw);
+        if (!normalized || handlesByKey.has(normalized.key)) continue;
+        handlesByKey.set(normalized.key, { raw, ...normalized });
+      }
+      if (handlesByKey.size === 0) continue;
+
+      const indexed: IndexedContact = {
+        identifier: record.identifier,
+        name: record.name,
+        nameKey: normalizeContactName(record.name),
+        handles: [...handlesByKey.values()].sort((left, right) =>
+          left.key.localeCompare(right.key, "en-US")
+        ),
+      };
+      byIdentifier.set(record.identifier, indexed);
+    }
+
+    this.contacts = [...byIdentifier.values()].sort(compareIndexedContacts);
+    for (const contact of this.contacts) {
+      for (const handle of contact.handles) {
+        const candidates = this.byHandle.get(handle.key) ?? [];
+        candidates.push(contact);
+        candidates.sort(compareIndexedContacts);
+        this.byHandle.set(handle.key, candidates);
+      }
+    }
+  }
+
+  status(): { available: boolean; contactCount: number; reason?: string } {
+    this.ensureLoaded();
+    return this.unavailableReason
+      ? { available: false, contactCount: 0, reason: this.unavailableReason }
+      : { available: true, contactCount: this.contacts.length };
+  }
+
+  lookup(handle: string): Contact {
+    const cleaned = handle.trim();
+    if (!cleaned) return { id: "", name: "(unknown)", tier: "unknown" };
+
+    const normalized = normalizeContactHandle(cleaned);
+    if (!normalized) return { id: cleaned, name: cleaned, tier: "unknown" };
+
+    this.ensureLoaded();
+    const candidates = this.byHandle.get(normalized.key) ?? [];
+    if (candidates.length === 1 && candidates[0].name) {
+      return { id: cleaned, name: candidates[0].name, tier: "known" };
+    }
+
+    return { id: cleaned, name: cleaned, tier: "unknown" };
+  }
+
+  resolve(query: string): ContactResolution {
+    const cleaned = query.trim();
+    if (!cleaned) return { status: "not_found" };
+
+    this.ensureLoaded();
+    if (this.unavailableReason) {
+      return { status: "unavailable", reason: this.unavailableReason };
+    }
+
+    const looksLikeHandle = cleaned.includes("@") || /\d/u.test(cleaned);
+    let matches: IndexedContact[];
+    if (looksLikeHandle) {
+      const normalized = normalizeContactHandle(cleaned);
+      matches = normalized ? [...(this.byHandle.get(normalized.key) ?? [])] : [];
+    } else {
+      const nameKey = normalizeContactName(cleaned);
+      matches = nameKey
+        ? this.contacts.filter((contact) => contact.nameKey.includes(nameKey))
+        : [];
+    }
+
+    matches.sort(compareIndexedContacts);
+    if (matches.length === 0) return { status: "not_found" };
+    if (matches.length === 1) {
+      return { status: "unique", candidate: publicCandidate(matches[0]) };
+    }
+    return { status: "ambiguous", candidates: matches.map(publicCandidate) };
+  }
+
+  handlesForName(name: string): string[] {
+    const resolution = this.resolve(name);
+    const candidates = resolution.status === "unique"
+      ? [resolution.candidate]
+      : resolution.status === "ambiguous"
+        ? resolution.candidates
+        : [];
+
+    const keys = new Set<string>();
+    for (const candidate of candidates) {
+      for (const handle of candidate.handles) {
+        const normalized = normalizeContactHandle(handle);
+        if (normalized) keys.add(normalized.searchKey);
+      }
+    }
+    return [...keys].sort((left, right) => left.localeCompare(right, "en-US"));
+  }
+
+  uniqueHandleMap(): Map<string, string> {
+    this.ensureLoaded();
+    const result = new Map<string, string>();
+    for (const [key, candidates] of this.byHandle) {
+      if (candidates.length === 1 && candidates[0].name) {
+        result.set(key, candidates[0].name);
+      }
+    }
+    return result;
+  }
+}
+
+const resolver = new UnifiedContactResolver();
+
+export function lookupContact(handle: string): Contact {
+  return resolver.lookup(handle);
+}
+
+export function resolveByName(name: string): string[] {
+  return resolver.handlesForName(name);
+}
+
+export function resolveContact(query: string): ContactResolution {
+  return resolver.resolve(query);
+}
+
+export function getAddressBookStatus(): { available: boolean; contactCount: number; reason?: string } {
+  return resolver.status();
 }
 
 export function loadAddressBook(): Map<string, string> {
-  const cache = new Map<string, string>();
-  const sources = getAddressBookSources();
-
-  // Load phone numbers
-  for (const dbPath of sources) {
-    try {
-      const sql = `SELECT r.ZFIRSTNAME, r.ZLASTNAME, p.ZFULLNUMBER FROM ZABCDRECORD r JOIN ZABCDPHONENUMBER p ON r.Z_PK = p.ZOWNER WHERE p.ZFULLNUMBER IS NOT NULL`;
-      const raw = execFileSync("sqlite3", ["-json", dbPath, sql], {
-        encoding: "utf-8",
-        timeout: 5_000,
-      }).trim();
-      if (!raw) continue;
-
-      const rows = JSON.parse(raw) as { ZFIRSTNAME: string | null; ZLASTNAME: string | null; ZFULLNUMBER: string }[];
-      for (const row of rows) {
-        const name = [row.ZFIRSTNAME, row.ZLASTNAME].filter(Boolean).join(" ").trim();
-        if (!name) continue;
-
-        // Store by normalized digits (last 10) for fuzzy matching
-        const digits = row.ZFULLNUMBER.replace(/\D/g, "");
-        if (digits.length >= 10) {
-          cache.set(digits.slice(-10), name);
-        }
-        // Also store full number with + prefix
-        if (row.ZFULLNUMBER.startsWith("+")) {
-          cache.set(row.ZFULLNUMBER, name);
-        }
-      }
-    } catch {
-      // Skip unreadable sources
-    }
-  }
-
-  // Load email addresses
-  for (const dbPath of sources) {
-    try {
-      const sql = `SELECT r.ZFIRSTNAME, r.ZLASTNAME, e.ZADDRESS FROM ZABCDRECORD r JOIN ZABCDEMAILADDRESS e ON r.Z_PK = e.ZOWNER WHERE e.ZADDRESS IS NOT NULL`;
-      const raw = execFileSync("sqlite3", ["-json", dbPath, sql], {
-        encoding: "utf-8",
-        timeout: 5_000,
-      }).trim();
-      if (!raw) continue;
-
-      const rows = JSON.parse(raw) as { ZFIRSTNAME: string | null; ZLASTNAME: string | null; ZADDRESS: string }[];
-      for (const row of rows) {
-        const name = [row.ZFIRSTNAME, row.ZLASTNAME].filter(Boolean).join(" ").trim();
-        if (!name) continue;
-        cache.set(row.ZADDRESS.toLowerCase(), name);
-      }
-    } catch {
-      // Skip
-    }
-  }
-
-  return cache;
-}
-
-function resolveFromAddressBook(handle: string): string | null {
-  if (addressBookCache === null) {
-    addressBookCache = loadAddressBook();
-  }
-
-  // Try exact match (email or +number)
-  const lower = handle.toLowerCase();
-  if (addressBookCache.has(lower)) return addressBookCache.get(lower)!;
-  if (addressBookCache.has(handle)) return addressBookCache.get(handle)!;
-
-  // Try last-10-digits match
-  const digits = handle.replace(/\D/g, "");
-  if (digits.length >= 10) {
-    const last10 = digits.slice(-10);
-    if (addressBookCache.has(last10)) return addressBookCache.get(last10)!;
-  }
-
-  return null;
-}
-
-/**
- * Reverse lookup: find handles from AddressBook whose resolved name matches the query.
- * Returns normalized keys (last-10-digits for phones, lowercase emails).
- */
-export function resolveByName(name: string): string[] {
-  if (addressBookCache === null) {
-    addressBookCache = loadAddressBook();
-  }
-
-  const lower = name.toLowerCase();
-  const matches: string[] = [];
-
-  for (const [key, resolvedName] of addressBookCache) {
-    if (resolvedName.toLowerCase().includes(lower)) {
-      matches.push(key);
-    }
-  }
-
-  return matches;
-}
-
-/**
- * Look up a contact by handle (phone number, email).
- * Uses macOS AddressBook for resolution, falls back to raw handle.
- */
-export function lookupContact(handle: string): Contact {
-  if (!handle) return { id: "", name: "(unknown)", tier: "unknown" };
-  const cleaned = handle.trim();
-
-  // Resolve from macOS AddressBook
-  const name = resolveFromAddressBook(cleaned);
-  if (name) {
-    return { id: cleaned, name, tier: "known" };
-  }
-
-  return { id: cleaned, name: cleaned, tier: "unknown" };
+  return resolver.uniqueHandleMap();
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -96,80 +96,46 @@ export function getDb(): Database.Database {
 /**
  * Extract text from NSAttributedString binary blob (attributedBody column).
  * On macOS 14+, some messages have null `text` but valid `attributedBody`.
- * The blob contains a bplist with the text encoded as UTF-8.
+ *
+ * Foundation's legacy archive stores the plain text after an NSString marker,
+ * a five-byte preamble, and a one- or three-byte UTF-8 length prefix.
  */
 export function extractTextFromAttributedBody(blob: Buffer): string | null {
   if (!blob || blob.length === 0) return null;
 
   try {
-    // Strategy 1: Look for NSString marker followed by the text
-    // The pattern is: "NSString" marker -> type byte -> length -> UTF-8 text
     const nsStringMarker = Buffer.from("NSString");
     let idx = blob.indexOf(nsStringMarker);
+    let markerLength = nsStringMarker.length;
+
     if (idx === -1) {
-      // Strategy 2: Look for "NSMutableString" marker
       const nsMutableMarker = Buffer.from("NSMutableString");
       idx = blob.indexOf(nsMutableMarker);
+      markerLength = nsMutableMarker.length;
     }
 
-    if (idx !== -1) {
-      // Advance past the marker + some header bytes to find text content
-      // The text typically follows a few bytes after the class name
-      const searchStart = idx + 8;
+    if (idx === -1) return null;
 
-      // Look for the actual text by scanning for a length-prefixed UTF-8 string
-      // Format varies but generally: skip class metadata, find text block
-      for (let i = searchStart; i < Math.min(searchStart + 50, blob.length - 2); i++) {
-        const byte = blob[i];
-        // Check for short string length byte (0x01-0x7f range indicates length)
-        if (byte > 1 && byte < 128) {
-          const potentialLen = byte;
-          if (i + 1 + potentialLen <= blob.length) {
-            const candidate = blob.subarray(i + 1, i + 1 + potentialLen);
-            // Validate it's printable UTF-8 and at least 2 chars (skip metadata bytes)
-            const text = candidate.toString("utf-8");
-            if (text.length >= 2 && /^[\x20-\x7E\u00A0-\uFFFF]+/.test(text)) {
-              return text.trim();
-            }
-          }
-        }
-      }
+    const contentStart = idx + markerLength + 5;
+    if (contentStart >= blob.length) return null;
+
+    const content = blob.subarray(contentStart);
+    let textLength: number;
+    let textStart: number;
+
+    if (content[0] === 0x81) {
+      if (content.length < 3) return null;
+      textLength = content[1] | (content[2] << 8);
+      textStart = 3;
+    } else {
+      textLength = content[0];
+      textStart = 1;
     }
 
-    // Strategy 3: Brute-force scan for longest UTF-8 text run
-    // This handles edge cases where the marker approach fails
-    let bestText = "";
-    let i = 0;
-    while (i < blob.length) {
-      // Skip null bytes and control characters
-      if (blob[i] < 0x20 && blob[i] !== 0x0A && blob[i] !== 0x0D) {
-        i++;
-        continue;
-      }
+    if (textLength === 0 || textStart + textLength > content.length) return null;
 
-      // Try to read a text run
-      let end = i;
-      while (end < blob.length && (blob[end] >= 0x20 || blob[end] === 0x0A || blob[end] === 0x0D)) {
-        end++;
-      }
-
-      if (end - i > bestText.length && end - i >= 2) {
-        const candidate = blob.subarray(i, end).toString("utf-8").trim();
-        // Filter out binary-looking strings and class names
-        if (
-          candidate.length > bestText.length &&
-          !candidate.startsWith("NS") &&
-          !candidate.startsWith("bplist") &&
-          !candidate.includes("streamtyped") &&
-          !/^[A-Z][a-z]+[A-Z]/.test(candidate) // Skip CamelCase class names
-        ) {
-          bestText = candidate;
-        }
-      }
-      i = end + 1;
-    }
-
-    return bestText.length >= 2 ? bestText : null;
+    const text = content.subarray(textStart, textStart + textLength).toString("utf-8");
+    return text.trim() || null;
   } catch {
     return null;
   }

--- a/src/db.ts
+++ b/src/db.ts
@@ -84,11 +84,15 @@ export function safeText(text: string | null): string | null {
 
 let _db: Database.Database | null = null;
 
+export function openReadonlyDatabase(databasePath: string): Database.Database {
+  const database = new Database(databasePath, { readonly: true, fileMustExist: true });
+  database.pragma("query_only = ON");
+  return database;
+}
+
 export function getDb(): Database.Database {
   if (!_db) {
-    _db = new Database(CHAT_DB, { readonly: true, fileMustExist: true });
-    _db.pragma("journal_mode = WAL");
-    _db.pragma("query_only = ON");
+    _db = openReadonlyDatabase(CHAT_DB);
   }
   return _db;
 }

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -3,8 +3,41 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getDb, DATE_EXPR, MSG_FILTER, repliedToCondition } from "../db.js";
-import { lookupContact } from "../contacts.js";
+import {
+  lookupContact,
+  normalizeContactHandle,
+  resolveContact,
+  type ContactCandidate,
+} from "../contacts.js";
 import { clamp, DEFAULT_LIMIT, MAX_LIMIT } from "../helpers.js";
+
+interface AmbiguousContactCandidate {
+  name: string;
+  handles: string[];
+}
+
+export function contactAmbiguityResult(
+  query: string,
+  candidates: AmbiguousContactCandidate[],
+) {
+  const ambiguity = {
+    status: "ambiguous" as const,
+    query,
+    candidates: candidates.map((candidate, index) => ({
+      candidate: index + 1,
+      name: candidate.name,
+      handles: candidate.handles,
+    })),
+  };
+
+  return {
+    content: [{
+      type: "text" as const,
+      text: `Multiple contacts match "${query}". Choose one candidate; no contact was guessed.\n\n${JSON.stringify(ambiguity, null, 2)}`,
+    }],
+    structuredContent: ambiguity,
+  };
+}
 
 export function registerContactTools(server: McpServer) {
   // -- list_contacts --
@@ -151,15 +184,17 @@ export function registerContactTools(server: McpServer) {
     "resolve_contact",
     "Fuzzy-match a name, phone number, or email to a contact record. Uses multi-level resolution: exact match, digits, fuzzy, and macOS AddressBook.",
     {
-      query: z.string().describe("Name, phone number, or email to resolve"),
+      query: z.string().trim().min(1).max(512).describe("Nonempty name, phone number, or email to resolve"),
     },
     { readOnlyHint: true, destructiveHint: false, openWorldHint: false },
     async (params) => {
       const db = getDb();
-      const query = params.query;
+      const query = params.query.trim();
+      const nativeResolution = resolveContact(query);
 
-      // Try direct lookup via contacts.ts
-      const contact = lookupContact(query);
+      if (nativeResolution.status === "ambiguous") {
+        return contactAmbiguityResult(query, nativeResolution.candidates);
+      }
 
       // Also search handles in the database
       const dbMatches = db.prepare(`
@@ -173,19 +208,64 @@ export function registerContactTools(server: McpServer) {
       `).all({ pattern: `%${query}%` }) as any[];
 
       // Search by name via display_name in chats
-      const nameMatches = db.prepare(`
+      const nameMatches = nativeResolution.status === "not_found" || nativeResolution.status === "unavailable"
+        ? db.prepare(`
         SELECT DISTINCT h.id
         FROM handle h
         JOIN chat_handle_join chj ON h.ROWID = chj.handle_id
         JOIN chat c ON chj.chat_id = c.ROWID
         WHERE c.display_name LIKE @pattern
         LIMIT 10
-      `).all({ pattern: `%${query}%` }) as any[];
+      `).all({ pattern: `%${query}%` }) as any[]
+        : [];
 
       const allHandles = new Set<string>();
-      if (contact.tier !== "unknown") allHandles.add(contact.id);
+      const messageCounts = new Map<string, number>();
+
+      const addCandidateHandles = (candidate: ContactCandidate) => {
+        for (const candidateHandle of candidate.handles) {
+          const normalized = normalizeContactHandle(candidateHandle);
+          const matches = normalized
+            ? db.prepare(`
+                SELECT h.id, COUNT(*) as msg_count
+                FROM handle h
+                JOIN message m ON m.handle_id = h.ROWID
+                WHERE h.id LIKE @pattern
+                  AND (m.text IS NOT NULL OR m.attributedBody IS NOT NULL)
+                GROUP BY h.id
+                ORDER BY msg_count DESC, h.id ASC
+                LIMIT 10
+              `).all({ pattern: `%${normalized.searchKey}%` }) as any[]
+            : [];
+
+          if (matches.length === 0) {
+            allHandles.add(candidateHandle);
+          } else {
+            for (const match of matches) {
+              allHandles.add(match.id);
+              messageCounts.set(match.id, match.msg_count);
+            }
+          }
+        }
+      };
+
+      if (nativeResolution.status === "unique") {
+        addCandidateHandles(nativeResolution.candidate);
+      }
       for (const m of dbMatches) allHandles.add(m.id);
       for (const m of nameMatches) allHandles.add(m.id);
+
+      if (nativeResolution.status !== "unique" && allHandles.size > 1) {
+        return contactAmbiguityResult(
+          query,
+          [...allHandles]
+            .sort((left, right) => left.localeCompare(right, "en-US"))
+            .map((handle) => ({
+              name: lookupContact(handle).name,
+              handles: [handle],
+            })),
+        );
+      }
 
       const results = [...allHandles].map((id) => {
         const c = lookupContact(id);
@@ -194,7 +274,7 @@ export function registerContactTools(server: McpServer) {
           handle: id,
           name: c.name,
           tier: c.tier,
-          message_count: match?.msg_count ?? 0,
+          message_count: messageCounts.get(id) ?? match?.msg_count ?? 0,
         };
       });
 

--- a/tests/contact-tool.test.ts
+++ b/tests/contact-tool.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  contactAmbiguityResult,
+  registerContactTools,
+} from "../src/tools/contacts.js";
+
+describe("resolve_contact compatibility hotfix", () => {
+  it("returns a successful structured ambiguity result without selecting a name", () => {
+    const result = contactAmbiguityResult("5555550143", [
+      { name: "Pat Lee", handles: ["+15555550143"] },
+      { name: "Sam Diaz", handles: ["+1 (555) 555-0143"] },
+    ]);
+
+    expect(result.structuredContent).toEqual({
+      status: "ambiguous",
+      query: "5555550143",
+      candidates: [
+        { candidate: 1, name: "Pat Lee", handles: ["+15555550143"] },
+        { candidate: 2, name: "Sam Diaz", handles: ["+1 (555) 555-0143"] },
+      ],
+    });
+    expect(result.content[0].text).toContain("no contact was guessed");
+  });
+
+  it("rejects an empty resolve_contact query before database access", () => {
+    const registrations = new Map<string, any[]>();
+    const server = {
+      tool(name: string, ...args: any[]) {
+        registrations.set(name, args);
+      },
+    };
+
+    registerContactTools(server as any);
+    const resolveRegistration = registrations.get("resolve_contact");
+    expect(resolveRegistration).toBeDefined();
+    const inputShape = resolveRegistration?.[1];
+    expect(inputShape.query.safeParse("   ").success).toBe(false);
+    expect(inputShape.query.safeParse("Sam Diaz").success).toBe(true);
+  });
+});

--- a/tests/contacts.test.ts
+++ b/tests/contacts.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  UnifiedContactResolver,
+  normalizeContactHandle,
+  normalizeContactName,
+  type UnifiedContactRecord,
+} from "../src/contacts.js";
+
+const CONTACTS: UnifiedContactRecord[] = [
+  {
+    identifier: "linked-contact",
+    name: "Jamie Rivera",
+    phones: ["+1 (555) 555-0100"],
+    emails: ["Jamie@Example.com"],
+  },
+  {
+    identifier: "stale-secondary-card",
+    name: "Pat Lee",
+    phones: ["+15555550143"],
+    emails: [],
+  },
+  {
+    identifier: "current-primary-card",
+    name: "Sam Diaz",
+    phones: ["+1 (555) 555-0143"],
+    emails: [],
+  },
+];
+
+function resolver(records: UnifiedContactRecord[] = CONTACTS): UnifiedContactResolver {
+  return new UnifiedContactResolver(() => ({ status: "ok", contacts: records }));
+}
+
+describe("contact normalization", () => {
+  it("normalizes formatted and E.164-style US numbers once", () => {
+    expect(normalizeContactHandle("+1 (555) 555-0143")).toEqual(
+      normalizeContactHandle("+15555550143"),
+    );
+  });
+
+  it("normalizes email casing and contact-name whitespace", () => {
+    expect(normalizeContactHandle(" Jamie@Example.COM ")).toEqual({
+      key: "email:jamie@example.com",
+      searchKey: "jamie@example.com",
+    });
+    expect(normalizeContactName("  Jamie   Rivera ")).toBe("jamie rivera");
+  });
+});
+
+describe("UnifiedContactResolver", () => {
+  it("uses one Apple-unified record for all of its linked handles", () => {
+    const contacts = resolver();
+
+    expect(contacts.lookup("5555550100")).toMatchObject({
+      name: "Jamie Rivera",
+      tier: "known",
+    });
+    expect(contacts.lookup("jamie@example.com")).toMatchObject({
+      name: "Jamie Rivera",
+      tier: "known",
+    });
+    expect(contacts.resolve("Jamie Rivera")).toEqual({
+      status: "unique",
+      candidate: {
+        name: "Jamie Rivera",
+        handles: ["Jamie@Example.com", "+1 (555) 555-0100"],
+      },
+    });
+  });
+
+  it("never labels a shared normalized phone as either conflicting card", () => {
+    const contacts = resolver();
+
+    expect(contacts.lookup("+15555550143")).toEqual({
+      id: "+15555550143",
+      name: "+15555550143",
+      tier: "unknown",
+    });
+    expect(contacts.resolve("+15555550143")).toEqual({
+      status: "ambiguous",
+      candidates: [
+        { name: "Pat Lee", handles: ["+15555550143"] },
+        { name: "Sam Diaz", handles: ["+1 (555) 555-0143"] },
+      ],
+    });
+  });
+
+  it("orders candidates deterministically regardless of native enumeration order", () => {
+    const forward = resolver(CONTACTS).resolve("5555550143");
+    const reverse = resolver([...CONTACTS].reverse()).resolve("5555550143");
+    expect(reverse).toEqual(forward);
+  });
+
+  it("returns normalized SQL search keys for a resolved name", () => {
+    expect(resolver().handlesForName("Jamie")).toEqual([
+      "5555550100",
+      "jamie@example.com",
+    ]);
+  });
+
+  it("rejects an empty name instead of matching the entire address book", () => {
+    const contacts = resolver();
+    expect(contacts.resolve("   ")).toEqual({ status: "not_found" });
+    expect(contacts.handlesForName("   ")).toEqual([]);
+  });
+
+  it("loads unified contacts once per server process", () => {
+    const loader = vi.fn(() => ({ status: "ok" as const, contacts: CONTACTS }));
+    const contacts = new UnifiedContactResolver(loader);
+
+    contacts.lookup("5555550100");
+    contacts.resolve("Jamie");
+    contacts.status();
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when Contacts is unavailable", () => {
+    const contacts = new UnifiedContactResolver(() => ({
+      status: "unavailable",
+      reason: "permission_denied",
+    }));
+
+    expect(contacts.lookup("5555550100").tier).toBe("unknown");
+    expect(contacts.resolve("Jamie")).toEqual({
+      status: "unavailable",
+      reason: "permission_denied",
+    });
+  });
+});

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   repliedToCondition,
   baseMessageConditions,
@@ -6,6 +10,7 @@ import {
   APPLE_EPOCH_OFFSET,
   extractTextFromAttributedBody,
   getMessageText,
+  openReadonlyDatabase,
 } from "../src/db.js";
 import {
   FOUNDATION_ATTRIBUTED_BODY_FIXTURES,
@@ -58,6 +63,28 @@ describe("DATE_EXPR", () => {
     expect(DATE_EXPR).toContain("datetime(");
     expect(DATE_EXPR).toContain("unixepoch");
     expect(DATE_EXPR).toContain("localtime");
+  });
+});
+
+describe("openReadonlyDatabase()", () => {
+  it("opens a non-WAL database without trying to change its journal mode", () => {
+    const directory = mkdtempSync(join(tmpdir(), "imessage-mcp-readonly-"));
+    const databasePath = join(directory, "chat.db");
+
+    try {
+      const writer = new Database(databasePath);
+      writer.exec("CREATE TABLE sample (value TEXT); INSERT INTO sample VALUES ('synthetic')");
+      expect(writer.pragma("journal_mode", { simple: true })).toBe("delete");
+      writer.close();
+
+      const reader = openReadonlyDatabase(databasePath);
+      expect(reader.prepare("SELECT value FROM sample").pluck().get()).toBe("synthetic");
+      expect(() => reader.prepare("INSERT INTO sample VALUES ('blocked')").run()).toThrow();
+      expect(reader.pragma("journal_mode", { simple: true })).toBe("delete");
+      reader.close();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -7,6 +7,11 @@ import {
   extractTextFromAttributedBody,
   getMessageText,
 } from "../src/db.js";
+import {
+  FOUNDATION_ATTRIBUTED_BODY_FIXTURES,
+  attributedBodyFixture,
+  malformedAttributedBodyFixture,
+} from "./fixtures/attributed-body.js";
 
 describe("repliedToCondition()", () => {
   it("returns a SQL string containing is_from_me", () => {
@@ -69,6 +74,19 @@ describe("extractTextFromAttributedBody()", () => {
   it("returns null when passed null/undefined input", () => {
     expect(extractTextFromAttributedBody(null as any)).toBeNull();
     expect(extractTextFromAttributedBody(undefined as any)).toBeNull();
+  });
+
+  it.each(Object.keys(FOUNDATION_ATTRIBUTED_BODY_FIXTURES) as Array<keyof typeof FOUNDATION_ATTRIBUTED_BODY_FIXTURES>)(
+    "decodes the Foundation-generated %s fixture exactly",
+    (name) => {
+      expect(extractTextFromAttributedBody(attributedBodyFixture(name))).toBe(
+        FOUNDATION_ATTRIBUTED_BODY_FIXTURES[name].text,
+      );
+    },
+  );
+
+  it("fails closed for a truncated Foundation archive", () => {
+    expect(extractTextFromAttributedBody(malformedAttributedBodyFixture())).toBeNull();
   });
 });
 

--- a/tests/fixtures/attributed-body.ts
+++ b/tests/fixtures/attributed-body.ts
@@ -1,0 +1,39 @@
+/**
+ * Synthetic NSAttributedString archives generated on macOS with Foundation:
+ *
+ *   NSArchiver.archivedData(withRootObject: NSAttributedString(string: text))
+ *
+ * The text is deliberately fake. These fixtures contain no Messages data.
+ */
+export const FOUNDATION_ATTRIBUTED_BODY_FIXTURES = {
+  short: {
+    text: "Hi from Foundation",
+    base64: "BAtzdHJlYW10eXBlZIHoA4QBQISEhBJOU0F0dHJpYnV0ZWRTdHJpbmcAhIQITlNPYmplY3QAhZKEhIQITlNTdHJpbmcBlIQBKxJIaSBmcm9tIEZvdW5kYXRpb26GhAJpSQESkoSEhAxOU0RpY3Rpb25hcnkAlIQBaQCGhg==",
+  },
+  long: {
+    text: "Long message block with exact bytes. ".repeat(8).trim(),
+    base64: "BAtzdHJlYW10eXBlZIHoA4QBQISEhBJOU0F0dHJpYnV0ZWRTdHJpbmcAhIQITlNPYmplY3QAhZKEhIQITlNTdHJpbmcBlIQBK4EoAUxvbmcgbWVzc2FnZSBibG9jayB3aXRoIGV4YWN0IGJ5dGVzLiBMb25nIG1lc3NhZ2UgYmxvY2sgd2l0aCBleGFjdCBieXRlcy4gTG9uZyBtZXNzYWdlIGJsb2NrIHdpdGggZXhhY3QgYnl0ZXMuIExvbmcgbWVzc2FnZSBibG9jayB3aXRoIGV4YWN0IGJ5dGVzLiBMb25nIG1lc3NhZ2UgYmxvY2sgd2l0aCBleGFjdCBieXRlcy4gTG9uZyBtZXNzYWdlIGJsb2NrIHdpdGggZXhhY3QgYnl0ZXMuIExvbmcgbWVzc2FnZSBibG9jayB3aXRoIGV4YWN0IGJ5dGVzLiBMb25nIG1lc3NhZ2UgYmxvY2sgd2l0aCBleGFjdCBieXRlcy4ghoQCaUkBgSgBkoSEhAxOU0RpY3Rpb25hcnkAlIQBaQCGhg==",
+  },
+  unicode: {
+    text: "Cafe\u0301 👋🏽 👩‍💻 日本語 العربية",
+    base64: "BAtzdHJlYW10eXBlZIHoA4QBQISEhBJOU0F0dHJpYnV0ZWRTdHJpbmcAhIQITlNPYmplY3QAhZKEhIQITlNTdHJpbmcBlIQBKzRDYWZlzIEg8J+Ri/Cfj70g8J+RqeKAjfCfkrsg5pel5pys6KqeINin2YTYudix2KjZitiphoQCaUkBHJKEhIQMTlNEaWN0aW9uYXJ5AJSEAWkAhoY=",
+  },
+  multiline: {
+    text: "first line\nsecond line\r\nthird line",
+    base64: "BAtzdHJlYW10eXBlZIHoA4QBQISEhBJOU0F0dHJpYnV0ZWRTdHJpbmcAhIQITlNPYmplY3QAhZKEhIQITlNTdHJpbmcBlIQBKyYgIGZpcnN0IGxpbmUKc2Vjb25kIGxpbmUNCnRoaXJkIGxpbmUgIIaEAmlJASaShISEDE5TRGljdGlvbmFyeQCUhAFpAIaG",
+  },
+  issue: {
+    text: "Hey Jordan, can you call me back at 555-0173 when you get a chance? Wanted to talk through the weekend plans before I book anything.",
+    base64: "BAtzdHJlYW10eXBlZIHoA4QBQISEhBJOU0F0dHJpYnV0ZWRTdHJpbmcAhIQITlNPYmplY3QAhZKEhIQITlNTdHJpbmcBlIQBK4GEAEhleSBKb3JkYW4sIGNhbiB5b3UgY2FsbCBtZSBiYWNrIGF0IDU1NS0wMTczIHdoZW4geW91IGdldCBhIGNoYW5jZT8gV2FudGVkIHRvIHRhbGsgdGhyb3VnaCB0aGUgd2Vla2VuZCBwbGFucyBiZWZvcmUgSSBib29rIGFueXRoaW5nLoaEAmlJAYGEAJKEhIQMTlNEaWN0aW9uYXJ5AJSEAWkAhoY=",
+  },
+} as const;
+
+export function attributedBodyFixture(name: keyof typeof FOUNDATION_ATTRIBUTED_BODY_FIXTURES): Buffer {
+  return Buffer.from(FOUNDATION_ATTRIBUTED_BODY_FIXTURES[name].base64, "base64");
+}
+
+export function malformedAttributedBodyFixture(): Buffer {
+  const source = attributedBodyFixture("issue");
+  const textStart = source.indexOf(Buffer.from("Hey Jordan"));
+  return source.subarray(0, textStart + 24);
+}

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const packageJson = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf8"));
+const serverJson = JSON.parse(readFileSync(resolve(ROOT, "server.json"), "utf8"));
+const pluginJson = JSON.parse(readFileSync(
+  resolve(ROOT, ".claude-plugin", "plugin.json"),
+  "utf8",
+));
+
+describe("1.3.1 release metadata", () => {
+  it("keeps package, MCP Registry, and Claude plugin versions aligned", () => {
+    expect(packageJson.version).toBe("1.3.1");
+    expect(serverJson.version).toBe(packageJson.version);
+    expect(serverJson.packages[0].version).toBe(packageJson.version);
+    expect(pluginJson.version).toBe(packageJson.version);
+  });
+
+  it("ships the native unified-contact helper", () => {
+    expect(packageJson.files).toContain("native");
+    expect(() => readFileSync(resolve(ROOT, "native", "contact-resolver.js"))).not.toThrow();
+  });
+
+  it("retains the declared 1.x Node compatibility floor", () => {
+    expect(packageJson.engines.node).toBe(">=18");
+  });
+});

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -55,6 +55,26 @@ describe("no network imports in source files", () => {
   });
 });
 
+describe("unified contact access", () => {
+  const contactsSource = readFileSync(path.join(SRC_DIR, "contacts.ts"), "utf-8");
+  const nativeResolver = readFileSync(
+    path.resolve(SRC_DIR, "..", "native", "contact-resolver.js"),
+    "utf-8",
+  );
+
+  it("uses a fixed native executable without a shell or sqlite3 subprocess", () => {
+    expect(contactsSource).toContain('"/usr/bin/osascript"');
+    expect(contactsSource).not.toContain('execFileSync("sqlite3"');
+    expect(contactsSource).not.toContain("execSync(");
+    expect(contactsSource).not.toContain("readdirSync");
+  });
+
+  it("asks Contacts.framework for unified records", () => {
+    expect(nativeResolver).toContain("request.unifyResults = true");
+    expect(nativeResolver).toContain("CNContactStore");
+  });
+});
+
 describe("MAX_LIMIT enforcement", () => {
   it("MAX_LIMIT is at most 500", () => {
     expect(MAX_LIMIT).toBeLessThanOrEqual(500);


### PR DESCRIPTION
## what changed

This creates the 1.3.1 compatibility release from v1.3.0.

- decodes Foundation attributed bodies with the correct fixed preamble and variable-length byte count
- replaces shell and per-source AddressBook scans with Apple unified Contacts resolution
- returns structured candidates for collisions and rejects empty contact queries
- removes the write journal-mode pragma from readonly SQLite startup
- aligns package, Claude plugin, and MCP Registry versions and adds gated release automation

## root causes

Issue #5 came from treating a preamble byte as the text length, which prefixed and truncated longer bodies.

Issue #6 came from mixing raw and normalized phone keys in a last-write-wins map across source databases. Input formatting and directory order could therefore select different names for the same number.

## verification

- Node 18.20.8 and Node 22.23.1
- build and typecheck
- 56 tests
- installed local tarball over real MCP stdio
- exact attributed-body reproduction from the packed package
- empty contact query rejection from the packed package
- 500 bounded local attributed bodies matched Foundation exactly
- 200 bounded local contact handles produced zero resolution-policy mismatches
- Claude plugin validation
- MCP Registry server.json validation
- no high or critical npm advisories

The bounded local checks emitted counts only and retained no message or contact values.

Two moderate transitive findings remain in the Node 18-compatible Hono adapter. They concern Windows static-file serving, while this release is a macOS stdio package. The 2.0 rebuild removes the v1 transport dependency surface.

## release boundary

The v1.3.1 tag workflow publishes npm with provenance, verifies the public tarball, publishes the GitHub and MCP Registry releases, then closes #5 and #6. None of those release actions run before tag creation. The hotfix is intentionally tagged directly from this v1.3.0-based release branch rather than merged into the later unreleased main history.
