### PR TITLE
fix: publish verified tarball as local path

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "imessage-mcp",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Read-only MCP for iMessage, SMS, MMS, and RCS history already present in Apple Messages on Mac.",
   "author": {
     "name": "Ani Potts",

--- a/.github/workflows/attest-canary.yml
+++ b/.github/workflows/attest-canary.yml
@@ -78,7 +78,7 @@ jobs:
           curl --fail --location --silent --show-error --max-filesize 4194304 "$ATTESTATION_URL" \
             --output evidence/candidate-attestations.json
           AUDIT_DIR=$(mktemp -d)
-          npm install --prefix "$AUDIT_DIR" --ignore-scripts --no-audit --no-fund \
+          npm install --prefix "$AUDIT_DIR" --omit=dev --ignore-scripts --no-audit --no-fund \
             "imessage-mcp@${CANDIDATE_VERSION}"
           npm --prefix "$AUDIT_DIR" audit signatures
           CANDIDATE_RUN_ID=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow release.yml \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -505,9 +505,7 @@ jobs:
               '
           fi
           echo "tarball=$(basename "$TARBALL")" >> "$GITHUB_OUTPUT"
-      - name: verify npm metadata, provenance, tarball identity, and production graph
-        shell: bash
-        run: |
+          # Keep verification in this step so downloaded release bytes never cross into a later shell boundary.
           npm view "imessage-mcp@${TARGET_VERSION}" --json | node -e '
             let body = "";
             process.stdin.on("data", (chunk) => {
@@ -548,7 +546,7 @@ jobs:
             "$PUBLIC_URL" --output "$RUNNER_TEMP/public.tgz"
           curl --fail --location --silent --show-error --max-filesize 4194304 \
             "$ATTESTATION_URL" --output "$RUNNER_TEMP/npm-attestations.json"
-          cmp "release-artifact/${{ steps.artifact.outputs.tarball }}" "$RUNNER_TEMP/public.tgz"
+          cmp "$TARBALL" "$RUNNER_TEMP/public.tgz"
           node -e '
             const fs = require("fs"), crypto = require("crypto");
             const document = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -451,9 +451,18 @@ jobs:
               "exact revision codeql",
               "publish verified npm artifact",
             ]) if (jobs.get(name) !== "success") process.exit(1);
-            if (jobs.get("verify public npm installation") !== "failure" ||
-                jobs.get("publish mcp registry metadata") !== "skipped" ||
-                jobs.get("publish github release") !== "skipped") process.exit(1);
+            const actualDownstream = [
+              jobs.get("verify public npm installation"),
+              jobs.get("publish mcp registry metadata"),
+              jobs.get("publish github release"),
+            ];
+            const allowedDownstream = [
+              ["failure", "skipped", "skipped"],
+              ["success", "failure", "skipped"],
+              ["success", "success", "failure"],
+            ];
+            if (!allowedDownstream.some((states) =>
+              states.every((state, index) => actualDownstream[index] === state))) process.exit(1);
           ' "$RUNNER_TEMP/original-run.json"
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,8 +195,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          TARBALL="release-artifact/${{ needs.verify-release.outputs.tarball }}"
+          TARBALL="./release-artifact/${{ needs.verify-release.outputs.tarball }}"
           EVIDENCE="release-artifact/security-evidence.json"
+          test -f "$TARBALL"
           gh attestation verify "$EVIDENCE" --repo "$GITHUB_REPOSITORY" \
             --signer-workflow anipotts/imessage-mcp/.github/workflows/attest-security-evidence.yml \
             --source-digest "$GITHUB_SHA" --deny-self-hosted-runners

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,7 +392,6 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ inputs.evidence_commit }}
           fetch-depth: 0
           persist-credentials: false
       - id: release
@@ -405,8 +404,11 @@ jobs:
           [[ "$TARGET_VERSION" =~ ^2\.[0-9]+\.[0-9]+(-(beta|rc)\.[1-9][0-9]*)?$ ]]
           [[ "$EVIDENCE_COMMIT" =~ ^[a-f0-9]{40}$ ]]
           [[ "$ORIGINAL_RUN_ID" =~ ^[1-9][0-9]*$ ]]
-          test "$(git rev-parse HEAD)" = "$EVIDENCE_COMMIT"
-          test "$(node -p "require('./package.json').version")" = "$TARGET_VERSION"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git rev-parse "${EVIDENCE_COMMIT}^{commit}")" = "$EVIDENCE_COMMIT"
+          PACKAGE_VERSION=$(git show "${EVIDENCE_COMMIT}:package.json" | \
+            node -e 'let body=""; process.stdin.on("data", (chunk) => body += chunk).on("end", () => process.stdout.write(JSON.parse(body).version))')
+          test "$PACKAGE_VERSION" = "$TARGET_VERSION"
           test "$(git cat-file -t "refs/tags/v${TARGET_VERSION}")" = "tag"
           test "$(git rev-parse "refs/tags/v${TARGET_VERSION}^{commit}")" = "$EVIDENCE_COMMIT"
           test -n "$SECURITY_SCAN_ALLOWED_SIGNER"
@@ -574,13 +576,16 @@ jobs:
                 !details.metadata.invocationId.includes("/actions/runs/" + runId + "/")) process.exit(1);
           ' "$RUNNER_TEMP/npm-attestations.json" "$RUNNER_TEMP/public.tgz"
           SCRATCH=$(mktemp -d)
-          npm install --prefix "$SCRATCH" --omit=dev --no-audit --no-fund "imessage-mcp@${TARGET_VERSION}"
-          test "$("$SCRATCH/node_modules/.bin/imessage-mcp" --version)" = "$TARGET_VERSION"
+          npm install --prefix "$SCRATCH" --omit=dev --ignore-scripts --no-audit --no-fund \
+            "imessage-mcp@${TARGET_VERSION}"
+          INSTALLED_VERSION=$(node -e '
+            const fs = require("fs");
+            process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).version);
+          ' "$SCRATCH/node_modules/imessage-mcp/package.json")
+          test "$INSTALLED_VERSION" = "$TARGET_VERSION"
           tar -xOf "$RUNNER_TEMP/public.tgz" package/npm-shrinkwrap.json \
             > "$RUNNER_TEMP/published-shrinkwrap.json"
-          tar -xOf "$RUNNER_TEMP/public.tgz" package/dist/verify-installed-graph.js \
-            > "$RUNNER_TEMP/verify-installed-graph.js"
-          node "$RUNNER_TEMP/verify-installed-graph.js" "$SCRATCH" "$RUNNER_TEMP/published-shrinkwrap.json"
+          npx tsx src/verify-installed-graph.ts "$SCRATCH" "$RUNNER_TEMP/published-shrinkwrap.json"
           npm --prefix "$SCRATCH" audit signatures
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -599,26 +604,29 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      VERSION: ${{ needs.resume-verify-public-npm.outputs.version }}
+      EVIDENCE_COMMIT: ${{ needs.resume-verify-public-npm.outputs.evidence_commit }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ needs.resume-verify-public-npm.outputs.evidence_commit }}
           fetch-depth: 0
           persist-credentials: false
       - name: install verified mcp publisher
         shell: bash
         run: |
+          test "$(git rev-parse "refs/tags/v${VERSION}^{commit}")" = "$EVIDENCE_COMMIT"
+          git show "${EVIDENCE_COMMIT}:server.json" > "$RUNNER_TEMP/release-server.json"
+          test "$(node -p "require('$RUNNER_TEMP/release-server.json').version")" = "$VERSION"
           curl --fail --location --silent --show-error \
             https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_darwin_arm64.tar.gz \
-            --output mcp-publisher.tar.gz
-          echo "e45e520892460732a4bdf37255576415d4a53ec171f8b913faf15bb1aef7cb77  mcp-publisher.tar.gz" | shasum -a 256 -c -
-          tar -xzf mcp-publisher.tar.gz mcp-publisher
-          chmod 700 mcp-publisher
-          ./mcp-publisher validate
+            --output "$RUNNER_TEMP/mcp-publisher.tar.gz"
+          echo "e45e520892460732a4bdf37255576415d4a53ec171f8b913faf15bb1aef7cb77  $RUNNER_TEMP/mcp-publisher.tar.gz" | shasum -a 256 -c -
+          tar -xzf "$RUNNER_TEMP/mcp-publisher.tar.gz" -C "$RUNNER_TEMP" mcp-publisher
+          chmod 700 "$RUNNER_TEMP/mcp-publisher"
+          "$RUNNER_TEMP/mcp-publisher" validate "$RUNNER_TEMP/release-server.json"
       - id: registry
         name: inspect exact registry state
-        env:
-          VERSION: ${{ needs.resume-verify-public-npm.outputs.version }}
         shell: bash
         run: |
           curl --fail --silent --show-error \
@@ -627,7 +635,7 @@ jobs:
           STATE=$(node -e '
             const fs = require("fs"), assert = require("assert/strict");
             const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-            const local = JSON.parse(fs.readFileSync("server.json", "utf8"));
+            const local = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/release-server.json", "utf8"));
             const normalize = (value) => Array.isArray(value) ? value.map(normalize) :
               value && typeof value === "object" ? Object.fromEntries(Object.entries(value)
                 .filter(([key, entry]) => key !== "isRequired" || entry !== false)
@@ -647,11 +655,9 @@ jobs:
       - name: publish matching registry metadata
         if: steps.registry.outputs.state == 'absent'
         run: |
-          ./mcp-publisher login github-oidc
-          ./mcp-publisher publish
+          "$RUNNER_TEMP/mcp-publisher" login github-oidc
+          "$RUNNER_TEMP/mcp-publisher" publish "$RUNNER_TEMP/release-server.json"
       - name: verify exact registry metadata
-        env:
-          VERSION: ${{ needs.resume-verify-public-npm.outputs.version }}
         shell: bash
         run: |
           for ATTEMPT in {1..20}; do
@@ -662,7 +668,7 @@ jobs:
               let body = "";
               process.stdin.on("data", (chunk) => body += chunk).on("end", () => {
                 const payload = JSON.parse(body);
-                const local = JSON.parse(fs.readFileSync("server.json", "utf8"));
+                const local = JSON.parse(fs.readFileSync(process.env.RUNNER_TEMP + "/release-server.json", "utf8"));
                 const normalize = (value) => Array.isArray(value) ? value.map(normalize) :
                   value && typeof value === "object" ? Object.fromEntries(Object.entries(value)
                     .filter(([key, entry]) => key !== "isRequired" || entry !== false)
@@ -763,7 +769,6 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ needs.resume-verify-public-npm.outputs.evidence_commit }}
           fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -785,6 +790,7 @@ jobs:
         shell: bash
         run: |
           test "$(git rev-parse "refs/tags/v${VERSION}^{commit}")" = "$EVIDENCE_COMMIT"
+          git show "${EVIDENCE_COMMIT}:server.json" > "$RUNNER_TEMP/release-server.json"
           PUBLIC_URL=$(npm view "imessage-mcp@${VERSION}" dist.tarball)
           test "$PUBLIC_URL" = "https://registry.npmjs.org/imessage-mcp/-/imessage-mcp-${VERSION}.tgz"
           curl --fail --location --silent --show-error --max-filesize 16777216 \
@@ -797,7 +803,7 @@ jobs:
             > "$RUNNER_TEMP/release.json"
           node -e '
             const fs = require("fs"), assert = require("assert/strict");
-            const local = JSON.parse(fs.readFileSync("server.json", "utf8"));
+            const local = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
             const normalize = (value) => Array.isArray(value) ? value.map(normalize) :
               value && typeof value === "object" ? Object.fromEntries(Object.entries(value)
                 .filter(([key, entry]) => key !== "isRequired" || entry !== false)
@@ -815,4 +821,4 @@ jobs:
             if (release.tag_name !== "v" + process.env.VERSION || release.draft ||
                 release.prerelease !== (process.env.PRERELEASE === "true") ||
                 JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
-          ' "$RUNNER_TEMP/registry.json" "$RUNNER_TEMP/release.json"
+          ' "$RUNNER_TEMP/registry.json" "$RUNNER_TEMP/release.json" "$RUNNER_TEMP/release-server.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,35 +340,70 @@ jobs:
     timeout-minutes: 10
     environment: github-release
     permissions:
+      attestations: read
       contents: write
     steps:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: verified-release-${{ needs.publish-npm.outputs.version }}
           path: release-artifact
-      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+      - id: draft-release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
+          tag_name: v${{ needs.publish-npm.outputs.version }}
+          draft: true
           prerelease: ${{ needs.publish-npm.outputs.prerelease == 'true' }}
           generate_release_notes: true
+          overwrite_files: true
+          fail_on_unmatched_files: true
           files: release-artifact/*
-      - name: verify exact github release
+      - name: verify complete draft, publish it, and verify immutable release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.publish-npm.outputs.version }}
           PRERELEASE: ${{ needs.publish-npm.outputs.prerelease }}
+          RELEASE_ID: ${{ steps.draft-release.outputs.id }}
         shell: bash
         run: |
-          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" \
-            > "$RUNNER_TEMP/release.json"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" > "$RUNNER_TEMP/draft.json"
           node -e '
             const fs = require("fs");
             const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
             const expectedAssets = fs.readdirSync("release-artifact").sort();
             const actualAssets = release.assets.map((asset) => asset.name).sort();
-            if (release.tag_name !== "v" + process.env.VERSION || release.draft ||
+            if (release.tag_name !== "v" + process.env.VERSION || !release.draft ||
                 release.prerelease !== (process.env.PRERELEASE === "true") ||
                 JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
-          ' "$RUNNER_TEMP/release.json"
+          ' "$RUNNER_TEMP/draft.json"
+          if [[ "$PRERELEASE" == "true" ]]; then
+            gh release edit "v${VERSION}" --repo "$GITHUB_REPOSITORY" --draft=false --prerelease
+          else
+            gh release edit "v${VERSION}" --repo "$GITHUB_REPOSITORY" --draft=false --prerelease=false --latest
+          fi
+          VERIFIED=false
+          for ATTEMPT in {1..20}; do
+            if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" \
+              > "$RUNNER_TEMP/release.json" && node -e '
+                const fs = require("fs");
+                const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                const expectedAssets = fs.readdirSync("release-artifact").sort();
+                const actualAssets = release.assets.map((asset) => asset.name).sort();
+                if (release.tag_name !== "v" + process.env.VERSION || release.draft || !release.immutable ||
+                    release.prerelease !== (process.env.PRERELEASE === "true") ||
+                    JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
+              ' "$RUNNER_TEMP/release.json"; then VERIFIED=true; break; fi
+            sleep 3
+          done
+          test "$VERIFIED" = "true"
+          ATTESTED=false
+          for ATTEMPT in {1..20}; do
+            if gh release verify "v${VERSION}" --repo "$GITHUB_REPOSITORY"; then ATTESTED=true; break; fi
+            sleep 3
+          done
+          test "$ATTESTED" = "true"
+          for ASSET in release-artifact/*; do
+            gh release verify-asset "v${VERSION}" "$ASSET" --repo "$GITHUB_REPOSITORY"
+          done
 
   resume-verify-public-npm:
     if: github.event_name == 'workflow_dispatch'
@@ -697,6 +732,7 @@ jobs:
     environment: github-release
     permissions:
       actions: read
+      attestations: read
       contents: write
     steps:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -724,41 +760,87 @@ jobs:
               const release = matches[0];
               const expectedAssets = fs.readdirSync("release-artifact").sort();
               const actualAssets = release.assets.map((asset) => asset.name).sort();
-              if (release.draft || release.prerelease !== (process.env.PRERELEASE === "true") ||
-                  JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
-              process.stdout.write("present");
+              if (release.prerelease !== (process.env.PRERELEASE === "true") ||
+                  new Set(actualAssets).size !== actualAssets.length ||
+                  actualAssets.some((asset) => !expectedAssets.includes(asset))) process.exit(1);
+              if (release.draft) process.stdout.write("draft");
+              else {
+                if (!release.immutable || JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
+                process.stdout.write("published");
+              }
             }
           ' "$RUNNER_TEMP/releases.json")
-          if [[ "$STATE" == "absent" ]]; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-          else
+          if [[ "$STATE" == "published" ]]; then
             echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
-      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+      - id: draft-release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         if: steps.release.outputs.publish == 'true'
         with:
           tag_name: v${{ needs.resume-verify-public-npm.outputs.version }}
+          draft: true
           prerelease: ${{ needs.resume-verify-public-npm.outputs.prerelease == 'true' }}
           generate_release_notes: true
+          overwrite_files: true
+          fail_on_unmatched_files: true
           files: release-artifact/*
-      - name: verify exact github release
+      - name: verify complete draft and publish it
+        if: steps.release.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.resume-verify-public-npm.outputs.version }}
+          PRERELEASE: ${{ needs.resume-verify-public-npm.outputs.prerelease }}
+          RELEASE_ID: ${{ steps.draft-release.outputs.id }}
+        shell: bash
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" > "$RUNNER_TEMP/draft.json"
+          node -e '
+            const fs = require("fs");
+            const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const expectedAssets = fs.readdirSync("release-artifact").sort();
+            const actualAssets = release.assets.map((asset) => asset.name).sort();
+            if (release.tag_name !== "v" + process.env.VERSION || !release.draft ||
+                release.prerelease !== (process.env.PRERELEASE === "true") ||
+                JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
+          ' "$RUNNER_TEMP/draft.json"
+          if [[ "$PRERELEASE" == "true" ]]; then
+            gh release edit "v${VERSION}" --repo "$GITHUB_REPOSITORY" --draft=false --prerelease
+          else
+            gh release edit "v${VERSION}" --repo "$GITHUB_REPOSITORY" --draft=false --prerelease=false --latest
+          fi
+      - name: verify exact immutable github release and assets
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.resume-verify-public-npm.outputs.version }}
           PRERELEASE: ${{ needs.resume-verify-public-npm.outputs.prerelease }}
         shell: bash
         run: |
-          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" \
-            > "$RUNNER_TEMP/release.json"
-          node -e '
-            const fs = require("fs");
-            const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-            const expectedAssets = fs.readdirSync("release-artifact").sort();
-            const actualAssets = release.assets.map((asset) => asset.name).sort();
-            if (release.tag_name !== "v" + process.env.VERSION || release.draft ||
-                release.prerelease !== (process.env.PRERELEASE === "true") ||
-                JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
-          ' "$RUNNER_TEMP/release.json"
+          VERIFIED=false
+          for ATTEMPT in {1..20}; do
+            if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" \
+              > "$RUNNER_TEMP/release.json" && node -e '
+                const fs = require("fs");
+                const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                const expectedAssets = fs.readdirSync("release-artifact").sort();
+                const actualAssets = release.assets.map((asset) => asset.name).sort();
+                if (release.tag_name !== "v" + process.env.VERSION || release.draft || !release.immutable ||
+                    release.prerelease !== (process.env.PRERELEASE === "true") ||
+                    JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
+              ' "$RUNNER_TEMP/release.json"; then VERIFIED=true; break; fi
+            sleep 3
+          done
+          test "$VERIFIED" = "true"
+          ATTESTED=false
+          for ATTEMPT in {1..20}; do
+            if gh release verify "v${VERSION}" --repo "$GITHUB_REPOSITORY"; then ATTESTED=true; break; fi
+            sleep 3
+          done
+          test "$ATTESTED" = "true"
+          for ASSET in release-artifact/*; do
+            gh release verify-asset "v${VERSION}" "$ASSET" --repo "$GITHUB_REPOSITORY"
+          done
 
   resume-verify-public-surfaces:
     if: github.event_name == 'workflow_dispatch'
@@ -768,6 +850,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       actions: read
+      attestations: read
       contents: read
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -821,7 +904,7 @@ jobs:
             const release = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
             const expectedAssets = fs.readdirSync("release-artifact").sort();
             const actualAssets = release.assets.map((asset) => asset.name).sort();
-            if (release.tag_name !== "v" + process.env.VERSION || release.draft ||
+            if (release.tag_name !== "v" + process.env.VERSION || release.draft || !release.immutable ||
                 release.prerelease !== (process.env.PRERELEASE === "true") ||
                 JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
           ' "$RUNNER_TEMP/registry.json" "$RUNNER_TEMP/release.json" "$RUNNER_TEMP/release-server.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,27 @@ on:
   push:
     tags:
       - "v2.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing npm version whose downstream publication must resume
+        required: true
+        type: string
+      evidence_commit:
+        description: Signed evidence commit targeted by the immutable release tag
+        required: true
+        type: string
+      failed_run_id:
+        description: Failed release run whose npm job succeeded
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   verify-release:
+    if: github.event_name == 'push'
     name: verify attested exact release artifact
     runs-on: macos-26
     timeout-minutes: 35
@@ -121,6 +136,7 @@ jobs:
           if-no-files-found: error
 
   release-secret-scan:
+    if: github.event_name == 'push'
     name: exact revision secret scan
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -134,6 +150,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-codeql:
+    if: github.event_name == 'push'
     name: exact revision codeql
     runs-on: macos-26
     timeout-minutes: 20
@@ -160,6 +177,7 @@ jobs:
           upload-database: false
 
   publish-npm:
+    if: github.event_name == 'push'
     name: publish verified npm artifact
     needs: [verify-release, release-secret-scan, release-codeql]
     runs-on: macos-26
@@ -221,6 +239,7 @@ jobs:
           fi
 
   verify-public-npm:
+    if: github.event_name == 'push'
     name: verify public npm installation
     needs: publish-npm
     runs-on: macos-26
@@ -250,7 +269,7 @@ jobs:
           curl --fail --location --silent --show-error "$URL" --output public.tgz
           cmp "release-artifact/${{ needs.publish-npm.outputs.tarball }}" public.tgz
           SCRATCH=$(mktemp -d)
-          npm install --prefix "$SCRATCH" --no-audit --no-fund "imessage-mcp@${VERSION}"
+          npm install --prefix "$SCRATCH" --omit=dev --no-audit --no-fund "imessage-mcp@${VERSION}"
           "$SCRATCH/node_modules/.bin/imessage-mcp" --version
           npm ls --prefix "$SCRATCH" --omit=dev --all --json > public-runtime-graph.json
           tar -xOf public.tgz package/npm-shrinkwrap.json > published-shrinkwrap.json
@@ -258,6 +277,7 @@ jobs:
           node verify-installed-graph.js "$SCRATCH" published-shrinkwrap.json
 
   publish-registry:
+    if: github.event_name == 'push'
     name: publish mcp registry metadata
     needs: [publish-npm, verify-public-npm]
     runs-on: macos-26
@@ -292,17 +312,20 @@ jobs:
             BODY=$(curl --fail --silent --show-error \
               "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.anipotts/imessage-mcp" || true)
             if printf '%s' "$BODY" | VERSION="$VERSION" node -e "
+              const fs = require('fs'), assert = require('assert/strict');
               let body='';
               process.stdin.on('data', chunk => body += chunk).on('end', () => {
                 const payload = JSON.parse(body);
-                const matched = Array.isArray(payload.servers) && payload.servers.some(entry => {
-                  const server = entry && entry.server;
-                  return server && server.name === 'io.github.anipotts/imessage-mcp' &&
-                    server.version === process.env.VERSION && Array.isArray(server.packages) &&
-                    server.packages.some(pkg => pkg.registryType === 'npm' &&
-                      pkg.identifier === 'imessage-mcp' && pkg.version === process.env.VERSION);
-                });
-                process.exit(matched ? 0 : 1);
+                const local = JSON.parse(fs.readFileSync('server.json', 'utf8'));
+                const normalize = value => Array.isArray(value) ? value.map(normalize) :
+                  value && typeof value === 'object' ? Object.fromEntries(Object.entries(value)
+                    .filter(([key, entry]) => key !== 'isRequired' || entry !== false)
+                    .map(([key, entry]) => [key, normalize(entry)])) : value;
+                const expected = normalize(local);
+                const matches = (payload.servers || []).map(entry => entry.server).filter(server =>
+                  server && server.name === expected.name && server.version === process.env.VERSION);
+                if (matches.length !== 1) process.exit(1);
+                assert.deepStrictEqual(matches[0], expected);
               });
             "; then exit 0; fi
             sleep 3
@@ -310,6 +333,7 @@ jobs:
           exit 1
 
   publish-github-release:
+    if: github.event_name == 'push'
     name: publish github release
     needs: [publish-npm, verify-public-npm, publish-registry]
     runs-on: macos-26
@@ -327,3 +351,468 @@ jobs:
           prerelease: ${{ needs.publish-npm.outputs.prerelease == 'true' }}
           generate_release_notes: true
           files: release-artifact/*
+      - name: verify exact github release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.publish-npm.outputs.version }}
+          PRERELEASE: ${{ needs.publish-npm.outputs.prerelease }}
+        shell: bash
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" \
+            > "$RUNNER_TEMP/release.json"
+          node -e '
+            const fs = require("fs");
+            const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const expectedAssets = fs.readdirSync("release-artifact").sort();
+            const actualAssets = release.assets.map((asset) => asset.name).sort();
+            if (release.tag_name !== "v" + process.env.VERSION || release.draft ||
+                release.prerelease !== (process.env.PRERELEASE === "true") ||
+                JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
+          ' "$RUNNER_TEMP/release.json"
+
+  resume-verify-public-npm:
+    if: github.event_name == 'workflow_dispatch'
+    name: resume by verifying existing public npm release
+    runs-on: macos-26
+    timeout-minutes: 20
+    environment: security-attestation
+    permissions:
+      actions: read
+      attestations: read
+      contents: read
+    env:
+      TARGET_VERSION: ${{ inputs.version }}
+      EVIDENCE_COMMIT: ${{ inputs.evidence_commit }}
+      ORIGINAL_RUN_ID: ${{ inputs.failed_run_id }}
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      prerelease: ${{ steps.release.outputs.prerelease }}
+      evidence_commit: ${{ steps.release.outputs.evidence_commit }}
+      tarball: ${{ steps.artifact.outputs.tarball }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.evidence_commit }}
+          fetch-depth: 0
+          persist-credentials: false
+      - id: release
+        name: verify protected recovery inputs and signed release lineage
+        env:
+          SECURITY_SCAN_ALLOWED_SIGNER: ${{ vars.SECURITY_SCAN_ALLOWED_SIGNER }}
+        shell: bash
+        run: |
+          test "$GITHUB_REF" = "refs/heads/main"
+          [[ "$TARGET_VERSION" =~ ^2\.[0-9]+\.[0-9]+(-(beta|rc)\.[1-9][0-9]*)?$ ]]
+          [[ "$EVIDENCE_COMMIT" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$ORIGINAL_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          test "$(git rev-parse HEAD)" = "$EVIDENCE_COMMIT"
+          test "$(node -p "require('./package.json').version")" = "$TARGET_VERSION"
+          test "$(git cat-file -t "refs/tags/v${TARGET_VERSION}")" = "tag"
+          test "$(git rev-parse "refs/tags/v${TARGET_VERSION}^{commit}")" = "$EVIDENCE_COMMIT"
+          test -n "$SECURITY_SCAN_ALLOWED_SIGNER"
+          umask 077
+          printf '%s\n' "$SECURITY_SCAN_ALLOWED_SIGNER" > "$RUNNER_TEMP/release-allowed-signers"
+          git -c gpg.format=ssh \
+            -c gpg.ssh.allowedSignersFile="$RUNNER_TEMP/release-allowed-signers" \
+            verify-commit "$EVIDENCE_COMMIT"
+          git -c gpg.format=ssh \
+            -c gpg.ssh.allowedSignersFile="$RUNNER_TEMP/release-allowed-signers" \
+            verify-tag "v${TARGET_VERSION}"
+          if [[ "$TARGET_VERSION" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$TARGET_VERSION" >> "$GITHUB_OUTPUT"
+          echo "evidence_commit=$EVIDENCE_COMMIT" >> "$GITHUB_OUTPUT"
+      - name: verify the failed run stopped after its successful npm publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh run view "$ORIGINAL_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --json conclusion,databaseId,event,headBranch,headSha,jobs,url,workflowName \
+            > "$RUNNER_TEMP/original-run.json"
+          node -e '
+            const fs = require("fs");
+            const run = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const version = process.env.TARGET_VERSION;
+            const commit = process.env.EVIDENCE_COMMIT;
+            const runId = process.env.ORIGINAL_RUN_ID;
+            if (String(run.databaseId) !== runId || run.workflowName !== "release 2.x" ||
+                run.event !== "push" || run.headBranch !== "v" + version ||
+                run.headSha !== commit || run.conclusion !== "failure") process.exit(1);
+            const jobs = new Map(run.jobs.map((job) => [job.name, job.conclusion]));
+            for (const name of [
+              "verify attested exact release artifact",
+              "exact revision secret scan",
+              "exact revision codeql",
+              "publish verified npm artifact",
+            ]) if (jobs.get(name) !== "success") process.exit(1);
+            if (jobs.get("verify public npm installation") !== "failure" ||
+                jobs.get("publish mcp registry metadata") !== "skipped" ||
+                jobs.get("publish github release") !== "skipped") process.exit(1);
+          ' "$RUNNER_TEMP/original-run.json"
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: npm ci
+      - id: artifact
+        name: retrieve and verify the exact artifact published by the failed run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          mkdir release-artifact
+          gh run download "$ORIGINAL_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "verified-release-${TARGET_VERSION}" --dir release-artifact
+          TARBALL=$(find release-artifact -maxdepth 1 -type f -name '*.tgz' -print)
+          test -n "$TARBALL"
+          test "$(printf '%s\n' "$TARBALL" | wc -l | tr -d ' ')" = "1"
+          test -f release-artifact/security-evidence.json
+          gh attestation verify release-artifact/security-evidence.json --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow anipotts/imessage-mcp/.github/workflows/attest-security-evidence.yml \
+            --source-digest "$EVIDENCE_COMMIT" --deny-self-hosted-runners
+          gh attestation verify "$TARBALL" --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow anipotts/imessage-mcp/.github/workflows/attest-security-evidence.yml \
+            --source-digest "$EVIDENCE_COMMIT" --deny-self-hosted-runners
+          npx tsx scripts/security-evidence.ts verify \
+            "$TARBALL" "$EVIDENCE_COMMIT" release-artifact/security-evidence.json
+          if [[ "$TARGET_VERSION" == *-* ]]; then
+            test ! -e release-artifact/canary-evidence.json
+          else
+            test -f release-artifact/canary-evidence.json
+            gh attestation verify release-artifact/canary-evidence.json --repo "$GITHUB_REPOSITORY" \
+              --signer-workflow anipotts/imessage-mcp/.github/workflows/attest-canary.yml \
+              --source-digest "$EVIDENCE_COMMIT" --deny-self-hosted-runners
+            TARBALL="$TARBALL" CANARY=release-artifact/canary-evidence.json \
+              VERSION="$TARGET_VERSION" EVIDENCE_COMMIT="$EVIDENCE_COMMIT" node -e '
+                const fs = require("fs"), crypto = require("crypto"), path = require("path");
+                const evidence = JSON.parse(fs.readFileSync(process.env.CANARY));
+                const hash = crypto.createHash("sha256").update(fs.readFileSync(process.env.TARBALL)).digest("hex");
+                if (evidence.schema_version !== 2 || evidence.repository !== "anipotts/imessage-mcp" ||
+                    evidence.subject.stable_evidence_commit !== process.env.EVIDENCE_COMMIT ||
+                    evidence.subject.stable_version !== process.env.VERSION ||
+                    evidence.subject.stable_package_file !== path.basename(process.env.TARBALL) ||
+                    evidence.subject.stable_package_sha256 !== hash || evidence.canary.elapsed_seconds < 604800 ||
+                    !Object.values(evidence.canary.exercises).every((value) => value === true) ||
+                    evidence.stable_derivation.direct_parent !== true ||
+                    evidence.stable_derivation.other_package_files_identical !== true) process.exit(1);
+              '
+          fi
+          echo "tarball=$(basename "$TARBALL")" >> "$GITHUB_OUTPUT"
+      - name: verify npm metadata, provenance, tarball identity, and production graph
+        shell: bash
+        run: |
+          npm view "imessage-mcp@${TARGET_VERSION}" --json | node -e '
+            let body = "";
+            process.stdin.on("data", (chunk) => {
+              body += chunk;
+              if (Buffer.byteLength(body) > 1048576) process.exit(1);
+            }).on("end", () => {
+              const metadata = JSON.parse(body);
+              process.stdout.write(JSON.stringify({
+                version: metadata.version,
+                gitHead: metadata.gitHead,
+                dist: {
+                  tarball: metadata.dist && metadata.dist.tarball,
+                  integrity: metadata.dist && metadata.dist.integrity,
+                  shasum: metadata.dist && metadata.dist.shasum,
+                  attestations: metadata.dist && metadata.dist.attestations,
+                },
+              }, null, 2) + "\n");
+            });
+          ' > "$RUNNER_TEMP/public-npm.json"
+          npm view imessage-mcp dist-tags --json > "$RUNNER_TEMP/dist-tags.json"
+          PUBLIC_URL=$(node -e '
+            const fs = require("fs");
+            const metadata = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const tags = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+            const version = process.env.TARGET_VERSION;
+            const commit = process.env.EVIDENCE_COMMIT;
+            const expectedUrl = "https://registry.npmjs.org/imessage-mcp/-/imessage-mcp-" + version + ".tgz";
+            const expectedTag = version.includes("-") ? "next" : "latest";
+            if (metadata.version !== version || (metadata.gitHead !== undefined && metadata.gitHead !== commit) ||
+                metadata.dist.tarball !== expectedUrl || typeof metadata.dist.integrity !== "string" ||
+                typeof metadata.dist.shasum !== "string" || tags[expectedTag] !== version ||
+                metadata.dist.attestations?.url !== "https://registry.npmjs.org/-/npm/v1/attestations/imessage-mcp@" + version ||
+                metadata.dist.attestations?.provenance?.predicateType !== "https://slsa.dev/provenance/v1") process.exit(1);
+            process.stdout.write(metadata.dist.tarball);
+          ' "$RUNNER_TEMP/public-npm.json" "$RUNNER_TEMP/dist-tags.json")
+          ATTESTATION_URL=$(node -p "require('$RUNNER_TEMP/public-npm.json').dist.attestations.url")
+          curl --fail --location --silent --show-error --max-filesize 16777216 \
+            "$PUBLIC_URL" --output "$RUNNER_TEMP/public.tgz"
+          curl --fail --location --silent --show-error --max-filesize 4194304 \
+            "$ATTESTATION_URL" --output "$RUNNER_TEMP/npm-attestations.json"
+          cmp "release-artifact/${{ steps.artifact.outputs.tarball }}" "$RUNNER_TEMP/public.tgz"
+          node -e '
+            const fs = require("fs"), crypto = require("crypto");
+            const document = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const bytes = fs.readFileSync(process.argv[2]);
+            const version = process.env.TARGET_VERSION;
+            const commit = process.env.EVIDENCE_COMMIT;
+            const runId = process.env.ORIGINAL_RUN_ID;
+            const entry = document.attestations.find((item) => item.predicateType === "https://slsa.dev/provenance/v1");
+            if (!entry) process.exit(1);
+            const payload = JSON.parse(Buffer.from(entry.bundle.dsseEnvelope.payload, "base64").toString("utf8"));
+            const subject = payload.subject && payload.subject.find((item) => item.name === "pkg:npm/imessage-mcp@" + version);
+            const definition = payload.predicate && payload.predicate.buildDefinition;
+            const workflow = definition && definition.externalParameters && definition.externalParameters.workflow;
+            const github = definition && definition.internalParameters && definition.internalParameters.github;
+            const dependency = definition && definition.resolvedDependencies && definition.resolvedDependencies.find(
+              (item) => item.digest && item.digest.gitCommit === commit,
+            );
+            const details = payload.predicate && payload.predicate.runDetails;
+            const expectedSha512 = crypto.createHash("sha512").update(bytes).digest("hex");
+            if (!subject || subject.digest.sha512 !== expectedSha512 ||
+                workflow.ref !== "refs/tags/v" + version ||
+                workflow.repository !== "https://github.com/anipotts/imessage-mcp" ||
+                workflow.path !== ".github/workflows/release.yml" || github.event_name !== "push" ||
+                !dependency || details.builder.id !== "https://github.com/actions/runner/github-hosted" ||
+                !details.metadata.invocationId.includes("/actions/runs/" + runId + "/")) process.exit(1);
+          ' "$RUNNER_TEMP/npm-attestations.json" "$RUNNER_TEMP/public.tgz"
+          SCRATCH=$(mktemp -d)
+          npm install --prefix "$SCRATCH" --omit=dev --no-audit --no-fund "imessage-mcp@${TARGET_VERSION}"
+          test "$("$SCRATCH/node_modules/.bin/imessage-mcp" --version)" = "$TARGET_VERSION"
+          tar -xOf "$RUNNER_TEMP/public.tgz" package/npm-shrinkwrap.json \
+            > "$RUNNER_TEMP/published-shrinkwrap.json"
+          tar -xOf "$RUNNER_TEMP/public.tgz" package/dist/verify-installed-graph.js \
+            > "$RUNNER_TEMP/verify-installed-graph.js"
+          node "$RUNNER_TEMP/verify-installed-graph.js" "$SCRATCH" "$RUNNER_TEMP/published-shrinkwrap.json"
+          npm --prefix "$SCRATCH" audit signatures
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: resumed-release-${{ steps.release.outputs.version }}
+          path: release-artifact
+          if-no-files-found: error
+          retention-days: 90
+
+  resume-publish-registry:
+    if: github.event_name == 'workflow_dispatch'
+    name: resume mcp registry publication
+    needs: resume-verify-public-npm
+    runs-on: macos-26
+    timeout-minutes: 15
+    environment: mcp-registry-release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.resume-verify-public-npm.outputs.evidence_commit }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: install verified mcp publisher
+        shell: bash
+        run: |
+          curl --fail --location --silent --show-error \
+            https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_darwin_arm64.tar.gz \
+            --output mcp-publisher.tar.gz
+          echo "e45e520892460732a4bdf37255576415d4a53ec171f8b913faf15bb1aef7cb77  mcp-publisher.tar.gz" | shasum -a 256 -c -
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+          chmod 700 mcp-publisher
+          ./mcp-publisher validate
+      - id: registry
+        name: inspect exact registry state
+        env:
+          VERSION: ${{ needs.resume-verify-public-npm.outputs.version }}
+        shell: bash
+        run: |
+          curl --fail --silent --show-error \
+            "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.anipotts/imessage-mcp" \
+            --output "$RUNNER_TEMP/registry-before.json"
+          STATE=$(node -e '
+            const fs = require("fs"), assert = require("assert/strict");
+            const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const local = JSON.parse(fs.readFileSync("server.json", "utf8"));
+            const normalize = (value) => Array.isArray(value) ? value.map(normalize) :
+              value && typeof value === "object" ? Object.fromEntries(Object.entries(value)
+                .filter(([key, entry]) => key !== "isRequired" || entry !== false)
+                .map(([key, entry]) => [key, normalize(entry)])) : value;
+            const expected = normalize(local);
+            const matches = (payload.servers || []).map((entry) => entry.server).filter(
+              (server) => server && server.name === expected.name && server.version === process.env.VERSION,
+            );
+            if (matches.length === 0) process.stdout.write("absent");
+            else {
+              if (matches.length !== 1) process.exit(1);
+              assert.deepStrictEqual(matches[0], expected);
+              process.stdout.write("present");
+            }
+          ' "$RUNNER_TEMP/registry-before.json")
+          echo "state=$STATE" >> "$GITHUB_OUTPUT"
+      - name: publish matching registry metadata
+        if: steps.registry.outputs.state == 'absent'
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
+      - name: verify exact registry metadata
+        env:
+          VERSION: ${{ needs.resume-verify-public-npm.outputs.version }}
+        shell: bash
+        run: |
+          for ATTEMPT in {1..20}; do
+            BODY=$(curl --fail --silent --show-error \
+              "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.anipotts/imessage-mcp" || true)
+            if printf '%s' "$BODY" | node -e '
+              const fs = require("fs"), assert = require("assert/strict");
+              let body = "";
+              process.stdin.on("data", (chunk) => body += chunk).on("end", () => {
+                const payload = JSON.parse(body);
+                const local = JSON.parse(fs.readFileSync("server.json", "utf8"));
+                const normalize = (value) => Array.isArray(value) ? value.map(normalize) :
+                  value && typeof value === "object" ? Object.fromEntries(Object.entries(value)
+                    .filter(([key, entry]) => key !== "isRequired" || entry !== false)
+                    .map(([key, entry]) => [key, normalize(entry)])) : value;
+                const expected = normalize(local);
+                const matches = (payload.servers || []).map((entry) => entry.server).filter(
+                  (server) => server && server.name === expected.name && server.version === process.env.VERSION,
+                );
+                if (matches.length !== 1) process.exit(1);
+                assert.deepStrictEqual(matches[0], expected);
+              });
+            '; then exit 0; fi
+            sleep 3
+          done
+          exit 1
+
+  resume-publish-github-release:
+    if: github.event_name == 'workflow_dispatch'
+    name: resume github release publication
+    needs: [resume-verify-public-npm, resume-publish-registry]
+    runs-on: macos-26
+    timeout-minutes: 10
+    environment: github-release
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: resumed-release-${{ needs.resume-verify-public-npm.outputs.version }}
+          path: release-artifact
+      - id: release
+        name: inspect exact github release state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.resume-verify-public-npm.outputs.version }}
+          PRERELEASE: ${{ needs.resume-verify-public-npm.outputs.prerelease }}
+        shell: bash
+        run: |
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            > "$RUNNER_TEMP/releases.json"
+          STATE=$(node -e '
+            const fs = require("fs");
+            const pages = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const releases = pages.flat();
+            const matches = releases.filter((release) => release.tag_name === "v" + process.env.VERSION);
+            if (matches.length === 0) process.stdout.write("absent");
+            else {
+              if (matches.length !== 1) process.exit(1);
+              const release = matches[0];
+              const expectedAssets = fs.readdirSync("release-artifact").sort();
+              const actualAssets = release.assets.map((asset) => asset.name).sort();
+              if (release.draft || release.prerelease !== (process.env.PRERELEASE === "true") ||
+                  JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
+              process.stdout.write("present");
+            }
+          ' "$RUNNER_TEMP/releases.json")
+          if [[ "$STATE" == "absent" ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        if: steps.release.outputs.publish == 'true'
+        with:
+          tag_name: v${{ needs.resume-verify-public-npm.outputs.version }}
+          prerelease: ${{ needs.resume-verify-public-npm.outputs.prerelease == 'true' }}
+          generate_release_notes: true
+          files: release-artifact/*
+      - name: verify exact github release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.resume-verify-public-npm.outputs.version }}
+          PRERELEASE: ${{ needs.resume-verify-public-npm.outputs.prerelease }}
+        shell: bash
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" \
+            > "$RUNNER_TEMP/release.json"
+          node -e '
+            const fs = require("fs");
+            const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const expectedAssets = fs.readdirSync("release-artifact").sort();
+            const actualAssets = release.assets.map((asset) => asset.name).sort();
+            if (release.tag_name !== "v" + process.env.VERSION || release.draft ||
+                release.prerelease !== (process.env.PRERELEASE === "true") ||
+                JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
+          ' "$RUNNER_TEMP/release.json"
+
+  resume-verify-public-surfaces:
+    if: github.event_name == 'workflow_dispatch'
+    name: verify resumed public surfaces
+    needs: [resume-verify-public-npm, resume-publish-registry, resume-publish-github-release]
+    runs-on: macos-26
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.resume-verify-public-npm.outputs.evidence_commit }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: resumed-release-${{ needs.resume-verify-public-npm.outputs.version }}
+          path: release-artifact
+      - name: verify npm, registry, github release, and tag agreement
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.resume-verify-public-npm.outputs.version }}
+          EVIDENCE_COMMIT: ${{ needs.resume-verify-public-npm.outputs.evidence_commit }}
+          PRERELEASE: ${{ needs.resume-verify-public-npm.outputs.prerelease }}
+          TARBALL: ${{ needs.resume-verify-public-npm.outputs.tarball }}
+        shell: bash
+        run: |
+          test "$(git rev-parse "refs/tags/v${VERSION}^{commit}")" = "$EVIDENCE_COMMIT"
+          PUBLIC_URL=$(npm view "imessage-mcp@${VERSION}" dist.tarball)
+          test "$PUBLIC_URL" = "https://registry.npmjs.org/imessage-mcp/-/imessage-mcp-${VERSION}.tgz"
+          curl --fail --location --silent --show-error --max-filesize 16777216 \
+            "$PUBLIC_URL" --output "$RUNNER_TEMP/public.tgz"
+          cmp "release-artifact/${TARBALL}" "$RUNNER_TEMP/public.tgz"
+          curl --fail --silent --show-error \
+            "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.anipotts/imessage-mcp" \
+            --output "$RUNNER_TEMP/registry.json"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" \
+            > "$RUNNER_TEMP/release.json"
+          node -e '
+            const fs = require("fs"), assert = require("assert/strict");
+            const local = JSON.parse(fs.readFileSync("server.json", "utf8"));
+            const normalize = (value) => Array.isArray(value) ? value.map(normalize) :
+              value && typeof value === "object" ? Object.fromEntries(Object.entries(value)
+                .filter(([key, entry]) => key !== "isRequired" || entry !== false)
+                .map(([key, entry]) => [key, normalize(entry)])) : value;
+            const expected = normalize(local);
+            const registry = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const matches = (registry.servers || []).map((entry) => entry.server).filter(
+              (server) => server && server.name === expected.name && server.version === process.env.VERSION,
+            );
+            if (matches.length !== 1) process.exit(1);
+            assert.deepStrictEqual(matches[0], expected);
+            const release = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+            const expectedAssets = fs.readdirSync("release-artifact").sort();
+            const actualAssets = release.assets.map((asset) => asset.name).sort();
+            if (release.tag_name !== "v" + process.env.VERSION || release.draft ||
+                release.prerelease !== (process.env.PRERELEASE === "true") ||
+                JSON.stringify(actualAssets) !== JSON.stringify(expectedAssets)) process.exit(1);
+          ' "$RUNNER_TEMP/registry.json" "$RUNNER_TEMP/release.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -583,13 +583,9 @@ jobs:
                 !details.metadata.invocationId.includes("/actions/runs/" + runId + "/")) process.exit(1);
           ' "$RUNNER_TEMP/npm-attestations.json" "$RUNNER_TEMP/public.tgz"
           SCRATCH=$(mktemp -d)
-          npm install --prefix "$SCRATCH" --omit=dev --ignore-scripts --no-audit --no-fund \
+          npm install --prefix "$SCRATCH" --omit=dev --no-audit --no-fund \
             "imessage-mcp@${TARGET_VERSION}"
-          INSTALLED_VERSION=$(node -e '
-            const fs = require("fs");
-            process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).version);
-          ' "$SCRATCH/node_modules/imessage-mcp/package.json")
-          test "$INSTALLED_VERSION" = "$TARGET_VERSION"
+          test "$("$SCRATCH/node_modules/.bin/imessage-mcp" --version)" = "$TARGET_VERSION"
           tar -xOf "$RUNNER_TEMP/public.tgz" package/npm-shrinkwrap.json \
             > "$RUNNER_TEMP/published-shrinkwrap.json"
           npx tsx src/verify-installed-graph.ts "$SCRATCH" "$RUNNER_TEMP/published-shrinkwrap.json"

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "imessage": {
       "command": "npx",
-      "args": ["-y", "imessage-mcp@2.0.0-beta.1"],
+      "args": ["-y", "imessage-mcp@2.0.0-beta.2"],
       "env": {
         "IMESSAGE_REFERENCE_KEY_FILE": "${HOME}/.imessage-mcp-reference-key",
         "IMESSAGE_DATABASE_ID_FILE": "${HOME}/.imessage-mcp-database-id"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0-beta.2] - 2026-08-26
+
+### Fixed
+- Trusted publication now passes npm an explicit local tarball path, preventing npm from interpreting the verified artifact path as a Git repository.
+
 ## [2.0.0-beta.1] - 2026-08-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The supported inputs are a live Mac `chat.db` and a faithful copy of that same M
 ## install
 
 ```sh
-npm install -g imessage-mcp@2.0.0-beta.1
+npm install -g imessage-mcp@2.0.0-beta.2
 umask 077
 openssl rand -base64 32 > "$HOME/.imessage-mcp-reference-key"
 openssl rand -base64 32 > "$HOME/.imessage-mcp-database-id"
@@ -72,7 +72,7 @@ Set a stricter ceiling at startup:
   "mcpServers": {
     "imessage": {
       "command": "npx",
-      "args": ["-y", "imessage-mcp@2.0.0-beta.1"],
+      "args": ["-y", "imessage-mcp@2.0.0-beta.2"],
       "env": {
         "IMESSAGE_PRIVACY": "redacted",
         "IMESSAGE_REFERENCE_KEY_FILE": "/Users/you/.imessage-mcp-reference-key",
@@ -108,7 +108,7 @@ Add the server through Codex MCP settings or the CLI:
 ```sh
 codex mcp add --env IMESSAGE_REFERENCE_KEY_FILE="$HOME/.imessage-mcp-reference-key" \
   --env IMESSAGE_DATABASE_ID_FILE="$HOME/.imessage-mcp-database-id" \
-  imessage -- npx -y imessage-mcp@2.0.0-beta.1
+  imessage -- npx -y imessage-mcp@2.0.0-beta.2
 ```
 
 Grant Full Disk Access to the Codex application that launches the process, then restart that application.
@@ -122,7 +122,7 @@ Add this entry to Claude Desktop's MCP configuration:
   "mcpServers": {
     "imessage": {
       "command": "npx",
-      "args": ["-y", "imessage-mcp@2.0.0-beta.1"],
+      "args": ["-y", "imessage-mcp@2.0.0-beta.2"],
       "env": {
         "IMESSAGE_REFERENCE_KEY_FILE": "/Users/you/.imessage-mcp-reference-key",
         "IMESSAGE_DATABASE_ID_FILE": "/Users/you/.imessage-mcp-database-id"
@@ -139,7 +139,7 @@ Grant Full Disk Access to Claude Desktop, restart it, and run `server_status`.
 ```sh
 claude mcp add imessage -e IMESSAGE_REFERENCE_KEY_FILE="$HOME/.imessage-mcp-reference-key" \
   -e IMESSAGE_DATABASE_ID_FILE="$HOME/.imessage-mcp-database-id" \
-  -- npx -y imessage-mcp@2.0.0-beta.1
+  -- npx -y imessage-mcp@2.0.0-beta.2
 ```
 
 ### cursor

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -9,7 +9,8 @@ Last updated: 2026-08-26
 | release | state | evidence boundary |
 | --- | --- | --- |
 | `1.3.1` | published and verified | npm `latest`, GitHub release, and MCP Registry agree on `1.3.1`; the public tarball reproduced the attributed-body and contact fixes before issues #5 and #6 closed |
-| `2.0.0-beta.1` | repaired source candidate, not yet published | local candidate gates, trusted publishing, and the bounded Messages.app comparison are green; exact-revision remote checks and a fresh direct-child sealed scan remain fail-closed publication gates |
+| `2.0.0-beta.1` | tagged, not published | all exact-revision prepublication gates passed, but npm rejected an ambiguous relative tarball argument before upload; the signed tag and failed workflow remain immutable evidence |
+| `2.0.0-beta.2` | release candidate, not yet published | carries identical runtime code with a corrected explicit local tarball path and must repeat the exact-revision scan, attestation, package, client, and public-artifact gates |
 | `2.0.0-rc.1` | not started | requires every beta gate and public prerelease verification |
 | `2.0.0` | blocked by design gate | requires a seven-day release-candidate canary; it cannot be promoted on the beta implementation day |
 
@@ -27,7 +28,7 @@ Last updated: 2026-08-26
 | dependency and secret audit | zero vulnerabilities reported on Node 22, 24, and 26 full gates; a redacted whole-working-tree Gitleaks scan found no leaks |
 | installed package | packed tarball passed doctor, stdio MCP, package-content, Codex, Claude Desktop/Code, and Cursor isolated configuration checks |
 | transports | real MCP requests passed over stdio, authenticated stateless loopback HTTP, and a local Tailscale Serve-style reverse-proxy simulation |
-| historical remote candidate | signed commit `4a569c777c052e41e61dcff200b8eaf0d751d509` passed CodeQL, dependency/package audit, secret scan, macOS 14/15/26 with Node 22/24/26, Intel package smoke, and the million-message job; the repaired source must repeat those checks |
+| exact beta.1 candidate | signed source `a7ede194e6f20436cc08e27621cbfed825969684` passed the full local gate on Node 22, 24, and 26; its signed evidence child `49b196bc5b3b8c1a80c7f35aac86bd2bcee43404` passed all 17 pull-request checks plus protected security attestation run `33027523175` |
 | trusted publishing | npm accepted the exact `anipotts/imessage-mcp`, `release.yml`, `npm-release` OIDC tuple with `npm publish` permission; no long-lived npm token is used |
 | public 1.3.1 package | release run `33021458297` published with provenance from signed commit `e0ab712c79869cc0e484e019dbbc1a123dce2628`; a fresh macOS 14/Node 22 registry install reported 25 tools, exact attributed-body decoding, and rejected empty contact queries |
 
@@ -64,6 +65,8 @@ Standard scan `f4a16214-e26d-42f0-b65e-57d21291d39f` completed with zero reporta
 Standard scan `7d588236-f899-4bf8-840a-97be019a2bd1` covered all 78 files at signed revision `2fffb0d6c379d85c81693547bed3798651166601` and found one release blocker: a copied-database alias could resolve to the live Messages database after lexical source classification. The repaired source derives the trusted live path from the OS account, compares canonical main-file and WAL identities before SQLite opens, rejects symlinked or non-regular copy WAL sidecars including dangling links, and preserves ordinary copies plus aliases to non-live copies. Synthetic regressions cover direct and parent symlinks, hardlinks, future WAL targets, ordinary copies, and missing paths. That scan is historical and cannot authorize publication; a fresh zero-finding scan of the final signed source remains required.
 
 Standard scan `981aad1d-eb9a-476b-8f20-45dae174ab18` completed with zero findings and complete 78-of-78-file coverage of signed revision `5f35345a1b807c2eddac72be277b5dc9ad1e457f`. Its stable copy-to-live database and WAL alias controls passed independent review. That review also identified a non-security diagnostic mismatch: for a supported symlink-selected copy, `doctor` described the lexical WAL sibling instead of the canonical WAL SQLite read. The candidate now derives the displayed WAL check from the successfully validated canonical database path and includes a live-WAL synthetic regression. The zero-finding scan is therefore historical; the final signed source must repeat it before publication.
+
+Standard scan `e4eff6f1-9192-4fb3-a085-e3c4d9a83bc4` completed with zero findings and complete 78-of-78-file coverage of signed revision `a7ede194e6f20436cc08e27621cbfed825969684`. Signed evidence child `49b196bc5b3b8c1a80c7f35aac86bd2bcee43404` contains the canonical scan bundle, and protected workflow run `33027523175` attested both the evidence and exact package bytes. Release run `33028109456` repeated the package, performance, secret, and CodeQL gates, then failed before publication because npm parsed `release-artifact/imessage-mcp-2.0.0-beta.1.tgz` as a GitHub shorthand instead of a local file. Beta.2 changes the release argument to an explicit `./release-artifact/...` path; its own direct-child scan and attestation remain mandatory.
 
 No stable claim will use the word complete while a known security or data-correctness defect remains.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "imessage-mcp",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imessage-mcp",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imessage-mcp",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "mcpName": "io.github.anipotts/imessage-mcp",
   "description": "Read-only MCP for iMessage, SMS, MMS, and RCS history in Apple Messages on Mac",
   "author": "Ani Potts",

--- a/release-status.json
+++ b/release-status.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 4,
-  "subject_version": "2.0.0-beta.1",
+  "subject_version": "2.0.0-beta.2",
   "prerelease_ready": true,
   "security_scan": {
     "authority": "signed_evidence_commit",

--- a/scripts/test-installed.ts
+++ b/scripts/test-installed.ts
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
     const install = path.join(scratch, "install");
     mkdirSync(install);
     writeFileSync(path.join(install, "package.json"), JSON.stringify({ private: true }));
-    execFileSync("npm", ["install", "--no-audit", "--no-fund", path.join(scratch, packed[0].filename)], {
+    execFileSync("npm", ["install", "--omit=dev", "--no-audit", "--no-fund", path.join(scratch, packed[0].filename)], {
       cwd: install,
       stdio: "ignore",
     });

--- a/security/scan/coverage.json
+++ b/security/scan/coverage.json
@@ -10,14 +10,14 @@
   "inventoryStrategy": "repository",
   "mode": "repository",
   "openQuestions": [],
-  "scanId": "e4eff6f1-9192-4fb3-a085-e3c4d9a83bc4",
+  "scanId": "fa2751e9-81f8-4821-a867-d58388af08a9",
   "schemaVersion": "1.0",
   "surfaces": [
     {
       "disposition": "no_issue_found",
       "id": "repository-integrity-assets",
       "label": "Repository integrity and public assets",
-      "notes": "Verified clean signed revision a7ede194e6f20436cc08e27621cbfed825969684, its signed audited parent, all 78 tracked files, three changed-file rereviews, 75 byte-identical inherited receipts, and five synthetic PNGs.",
+      "notes": "Verified clean signed revision, all 81 tracked files, beta.2 delta, aligned versions, allowlisted package, exact shrinkwrap integrity, pinned Actions, and five synthetic or branding-only PNGs.",
       "receiptRefs": [],
       "riskArea": "Private-data publication and source ambiguity"
     },
@@ -25,7 +25,7 @@
       "disposition": "no_issue_found",
       "id": "database-source-boundary",
       "label": "Database source, read-only open, and copy/live boundary",
-      "notes": "Reviewed canonical path and device/inode checks, WAL sidecar rejection before SQLite, readonly/fileMustExist/query_only opens, identity pinning, copy sync fingerprints, canonical doctor WAL reporting, and synthetic regressions.",
+      "notes": "Reviewed canonical path and identity checks, pre-open live main/WAL alias rejection, readonly/fileMustExist/query_only SQLite, rollback-only snapshots, identity and version checks, lineage, and copy fingerprints. Evidence: src/database.ts:32-129,225-238,306-468,494-563.",
       "receiptRefs": [],
       "riskArea": "Live Messages disclosure or mutation"
     },
@@ -33,7 +33,7 @@
       "disposition": "no_issue_found",
       "id": "schema-query-correctness",
       "label": "Schema capabilities and query repositories",
-      "notes": "Reviewed capability-gated SQL, bound caller values, conversations, messages, analytics, sync, date handling, reactions, receipts, edits, retractions, and keyset cursors.",
+      "notes": "Reviewed capability-gated parameterized SQL, bounded discovered identifiers, conversations, messages, analytics, sync, dates/DST, reactions, receipts, edits, retractions, service families, and keyset cursors.",
       "receiptRefs": [],
       "riskArea": "SQL injection, attribution, completeness, and snapshot integrity"
     },
@@ -41,39 +41,39 @@
       "disposition": "no_issue_found",
       "id": "http-auth-transport",
       "label": "HTTP authentication and transport limits",
-      "notes": "Reviewed loopback bind, constant-time bearer checks before body parsing, Host/Origin allowlists, request/response limits, rate, concurrency, and deadlines.",
+      "notes": "Reviewed loopback bind, bounded constant-time bearer verification before body parsing, Host/Origin checks, POST routing, size, socket, rate, two-call concurrency, and deadline limits. Evidence: src/transport.ts:15-24,38-71,91-168,225-355.",
       "receiptRefs": [],
-      "riskArea": "Unauthorized remote access and resource exhaustion"
+      "riskArea": "Unauthorized access and resource exhaustion"
     },
     {
       "disposition": "no_issue_found",
       "id": "secret-handling-references",
       "label": "Secret files, opaque references, and lineage",
-      "notes": "Reviewed O_NOFOLLOW 0600 operator-owned regular-file loading, independent secrets, AES-GCM references, and database-lineage scoping.",
+      "notes": "Reviewed exclusive secret sources, O_NOFOLLOW, ownership, mode 0600, file and size checks, independent keys, lineage-derived AES-256-GCM references, and strict rejection.",
       "receiptRefs": [],
       "riskArea": "Secret substitution and cross-archive reference reuse"
     },
     {
       "disposition": "no_issue_found",
-      "id": "native-decoders-contacts",
-      "label": "Foundation decoder and unified Contacts adapter",
-      "notes": "Reviewed fixed executables/scripts, no shell, minimal environment, bounded IPC, timeouts, class allowlists, Contacts authorization, and input/output limits.",
+      "id": "native-decoders-contacts-doctor",
+      "label": "Foundation decoder, Contacts adapter, and doctor",
+      "notes": "Reviewed fixed helpers, no shell, bounded IPC/output/deadlines, minimal decoder environment, class allowlist, bounded legacy parser, live-only Contacts, output validation, and read-only doctor. Doctor's fixed same-authority Contacts helper inherits the parent environment but has no environment-read or external-output sink.",
       "receiptRefs": [],
-      "riskArea": "Unsafe deserialization, subprocess abuse, and identity leakage"
+      "riskArea": "Unsafe deserialization, subprocess abuse, identity leakage, or diagnostic mutation"
     },
     {
       "disposition": "no_issue_found",
       "id": "privacy-results-logging",
       "label": "Privacy projection, results, errors, and diagnostics",
-      "notes": "Reviewed full, redacted, and aggregate projections, forbidden-field assertions, grapheme-safe snippets, bounded summaries, safe errors, and stderr-only redacted diagnostics.",
+      "notes": "Reviewed request-only tightening, full/redacted/aggregate projection, forbidden-field assertions before both result forms, safe error keys, grapheme-safe snippets, 4 MiB result ceiling, deterministic summaries, and metadata-only stderr diagnostics.",
       "receiptRefs": [],
-      "riskArea": "Disclosure above the configured ceiling"
+      "riskArea": "Disclosure above the startup ceiling"
     },
     {
       "disposition": "no_issue_found",
       "id": "memory-search-budgets",
       "label": "Memory-only search and resource budgets",
-      "notes": "Reviewed :memory: indexing, sizing cap, exact/token/phrase/trigram behavior, literal wildcard handling, worker deadlines, decoder locks, and query budgets.",
+      "notes": "Reviewed SQLite :memory: indexing, lower-of-512-MiB-or-memory cap, footprint checks, exact/token/phrase/trigram and literal wildcard behavior, decoder serialization, worker deadlines, and query budgets.",
       "receiptRefs": [],
       "riskArea": "Persistent sensitive indexes and denial of service"
     },
@@ -81,15 +81,15 @@
       "disposition": "no_issue_found",
       "id": "package-release-supply-chain",
       "label": "Package and release supply chain",
-      "notes": "Reviewed exact dependencies, shrinkwrap integrity, package allowlist, pinned Actions, permission-separated jobs, signed direct-child evidence, attestations, OIDC publication, and canary derivation.",
+      "notes": "Reviewed signed direct-child evidence, exact parent and scan binding, protected attestations, digest checks, explicit ./release-artifact publication, npm provenance/OIDC, public byte comparison, separate Registry/GitHub jobs, and stable canary derivation. External mappings remain action-time prerequisites.",
       "receiptRefs": [],
       "riskArea": "Artifact substitution and unauthorized publication"
     },
     {
       "disposition": "no_issue_found",
-      "id": "tool-api-client-manifests",
+      "id": "tool-api-client-contract",
       "label": "Seven-tool API, client manifests, and documentation",
-      "notes": "Reviewed exactly seven read-only registrations, MCP schemas, installed entrypoint, canonical doctor diagnostics, Claude/Codex/Cursor metadata, Android SMS/RCS boundary, privacy claims, and unsupported behavior.",
+      "notes": "Reviewed exactly seven read-only tools, schemas, installed entrypoint, Claude/Codex/Cursor metadata, Mac-local coverage, Android SMS/MMS/RCS boundary, privacy claims, copied/live behavior, and unsupported operations.",
       "receiptRefs": [],
       "riskArea": "Unexpected write capability or misleading deployment contract"
     }

--- a/security/scan/findings.json
+++ b/security/scan/findings.json
@@ -1,6 +1,6 @@
 {
   "documentType": "codex-security.findings",
   "findings": [],
-  "scanId": "e4eff6f1-9192-4fb3-a085-e3c4d9a83bc4",
+  "scanId": "fa2751e9-81f8-4821-a867-d58388af08a9",
   "schemaVersion": "1.0"
 }

--- a/security/scan/scan-manifest.json
+++ b/security/scan/scan-manifest.json
@@ -5,22 +5,21 @@
       {
         "mediaType": "application/json",
         "path": "findings.json",
-        "sha256": "47bafbcc829842f405f51c22a2b070b485606da7e7a796532a781600ffe7098c"
+        "sha256": "ee74508517ebd80977332e42acc683ad0027e5f07d8ec6d4df75a82fc761528a"
       },
       {
         "mediaType": "application/json",
         "path": "coverage.json",
-        "sha256": "b292ebc76c2e58a0572a541fc855b649b5862ab09ee51aa83b20fa362355d3b7"
+        "sha256": "e29e03b281c1e81083221ccfa4a963e13c94ff67d3b80e888928c83a1123770f"
       }
     ],
-    "completedAt": "2026-08-27T00:21:31.196841Z",
+    "completedAt": "2026-08-27T02:04:37.589236Z",
     "coverageRef": "coverage.json",
     "findingsRef": "findings.json",
-    "id": "e4eff6f1-9192-4fb3-a085-e3c4d9a83bc4",
+    "id": "fa2751e9-81f8-4821-a867-d58388af08a9",
     "preservedSources": {
-      "checkpoints/36e2772b843d75244760651ca1056b48d43ecc392966aa77da1f15db2bed8210.json": "933554f1faade15735bed480e04f7de11c5f95cc5ea8978f3d4a4e5265a1be6a",
-      "checkpoints/86445328811a8ff7a94ebc35032d344ab22e20d6685c5f17a58c8675dd33078b.json": "881e7674c4f614e5e831fef13965e315b303ed458453cefc43963ec7c9f0019d",
-      "checkpoints/cf8f12929afc2a762b0fb1ca24e80687b0122d877e9e72ed9aeeef88618e95ba.json": "cf8f12929afc2a762b0fb1ca24e80687b0122d877e9e72ed9aeeef88618e95ba"
+      "checkpoints/4337730e81b01b6c1153b42ae01b6f868cfb1cba325d1cd72531ba1a346ab77e.json": "4337730e81b01b6c1153b42ae01b6f868cfb1cba325d1cd72531ba1a346ab77e",
+      "checkpoints/5e64319c5c2226d29d6c29c2fe325f993a162a075a3a3440ed70084b936cdf51.json": "29354e4640c4645ebef03f4c164129145bf03abc1406db902623859ee3327488"
     },
     "producer": {
       "name": "codex-security-plugin",
@@ -28,74 +27,85 @@
     },
     "scope": {
       "artifactsReviewed": [
-        "All 78 tracked files",
-        "Immutable Git delta from zero-finding signed parent 5f35345a1b807c2eddac72be277b5dc9ad1e457f",
-        "Five bundled PNG assets",
-        "Node 22/24/26 complete verification results",
-        "Packed-tarball stdio, authenticated HTTP, doctor, client-config, audit, metadata, release-gate, and package-content results"
+        "All 81 tracked files",
+        "Signed beta.2 source commit and immutable Git delta from beta.1 source",
+        "Five bundled PNG assets and their manifest",
+        "Supported Node 22, 24, and 26 verification results",
+        "Packed-tarball stdio, authenticated HTTP, doctor, named-client, metadata, audit, secret-scan, package-content, release-gate, and million-message performance results"
       ],
-      "context": "Strict read-only Apple Messages beta release candidate. Stable main/WAL aliases, canonical doctor WAL reporting, privacy ceilings, transport bounds, and signed scan-to-package release lineage were specifically checked.",
+      "context": "Release-authoritative review focused on read-only database identity, correctness/privacy boundaries, native decoding, resource limits, and signed scan-to-package OIDC release lineage.",
       "excludePaths": [],
       "includePaths": [
         "."
       ],
       "limitations": [
-        "The same-macOS-account adversarial path-replacement race was explicitly outside the supplied threat model and is documented as unsupported.",
-        "Tailscale route mutation was not performed; authenticated loopback HTTP and a local Tailscale Serve-style reverse-proxy simulation own the automated transport evidence."
+        "Adversarial path replacement by another process under the same macOS account is outside the documented copied-source threat model.",
+        "No Tailscale route was created or changed; loopback HTTP and proxy simulation own transport evidence.",
+        "Offline source review cannot prove current provider OIDC mappings or final public state; those are checked at publication time."
       ],
-      "runtimeStatus": "Build, typecheck, 110 tests, installed-tarball checks, all seven tools over stdio and authenticated HTTP, metadata, release gate, package audit, whole-tree secret scan, and identical dry-run package bytes passed locally on Node 22, 24, and 26.",
-      "summary": "Whole-repository Standard security review of the exact clean signed Git revision a7ede194e6f20436cc08e27621cbfed825969684.",
-      "validationMode": "Independent full-file baseline with immutable receipt reuse for 75 Git-proven byte-identical files, independent rereview of all three changed files and transitive controls, separate architecture delta review, parent control review, and supported-runtime dynamic gates."
+      "runtimeStatus": "Build, typecheck, 110 tests, installed-tarball checks, all seven tools over stdio and authenticated HTTP, package metadata and release gates, dependency audit, whole-tree secret scan, dry-run tarball publication, and supported Node 22/24/26 verification passed. The million-message fixture met documented cold-index, warm-search, metadata, concurrency, and memory ceilings.",
+      "summary": "Whole-repository Standard security review of exact clean signed Git revision 4f68be639b4963538c2ff474ef82fe3b292130af for imessage-mcp 2.0.0-beta.2.",
+      "validationMode": "Independent complete 81-file baseline, separate architecture mapping, focused release/HTTP/privacy review, parent reconciliation, and supported-runtime dynamic gates."
     },
-    "sealedAt": "2026-08-27T00:21:31.196841Z",
-    "startedAt": "2026-08-27T00:15:56.357876Z",
+    "sealedAt": "2026-08-27T02:04:37.589236Z",
+    "startedAt": "2026-08-27T01:41:16.185754Z",
     "status": "completed",
     "target": {
       "displayName": "imessage-mcp",
       "kind": "git_revision",
-      "revision": "a7ede194e6f20436cc08e27621cbfed825969684",
+      "revision": "4f68be639b4963538c2ff474ef82fe3b292130af",
       "targetId": "target_sha256_91a5cfb7b3d17e1fa8fb342de4bf5e1ed933375ae15ffb07b6229c2a5086c983"
     },
     "threatModel": {
       "assets": [
-        "Apple Messages history, including visible bodies, handles, names, timestamps, attachments, and lifecycle state.",
-        "Unified Contacts identities read only when the live database and existing Contacts permission are both available.",
-        "Full Disk Access and local process authority inherited from the launching MCP client.",
-        "HTTP bearer token, opaque-reference key, and independent database-lineage identity.",
-        "Decoded message text, memory-only search indexes, privacy projections, cursors, and diagnostic outputs.",
-        "Signed source/evidence commits, canonical scan evidence, package bytes, provenance, tags, and registry metadata."
+        "Apple Messages history, visible bodies, handles, names, timestamps, attachments, conversation relationships, edits, retractions, reactions, receipts, and group events.",
+        "Unified Contacts identities read only for a live source when existing macOS Contacts authorization is available.",
+        "Correct service, sender, contact, conversation, pagination, date, and lifecycle attribution.",
+        "The launching client's Full Disk Access and same-account process authority.",
+        "HTTP bearer token, opaque-reference key, independent database-lineage identity, masking key, references, and sync cursors.",
+        "Decoded text and metadata in worker memory, including the memory-only exact, FTS, and trigram index.",
+        "Privacy-ceiling enforcement, bounded outputs, strict 2.x read-only behavior, signed evidence, exact package bytes, attestations, tags, and registry metadata."
       ],
       "assumptions": [
-        "Supported deployment is macOS 14+ using the CLI over stdio or authenticated loopback HTTP behind operator-managed Tailscale Serve.",
-        "Tailscale configuration, tailnet ACLs, Full Disk Access, Contacts permission, downstream MCP-client processing, and Apple Messages as sole live writer are external operator/platform controls.",
-        "The copied database, its sidecars, and their parent directory remain controlled by the operator and unchanged while starting and running; adversarial replacement by another process under the same macOS account is outside the supplied threat model.",
-        "Direct in-process embedding shares the embedding caller's local authority and must preserve RuntimeConfig invariants.",
-        "The exact signed revision a7ede194e6f20436cc08e27621cbfed825969684 and all 78 tracked files were covered: three changed files were independently rereviewed with their transitive controls and Git proved the other 75 byte-identical to the fully audited zero-finding parent. Dynamic release gates passed locally on supported Node 22, 24, and 26."
+        "Supported runtime is macOS 14+ with Node 22, 24, or 26; Full Disk Access, Contacts permission, filesystem ownership, and downstream client processing are external controls.",
+        "Apple Messages is the sole live writer. A copied database, sidecars, and parent directory remain operator-controlled and unchanged; adversarial same-account replacement is unsupported.",
+        "Direct in-process embedding is same-authority use and must preserve RuntimeConfig cross-field invariants.",
+        "The exact clean signed revision and all 81 tracked files were reviewed. Runtime files under bin, native, and src are byte-identical to the clean beta.1 source; beta.2 changes version/client/release metadata, documentation, the explicit local tarball path, and its regression test.",
+        "The checked-in scan bundle at the source revision is historical beta.1 evidence and cannot authorize beta.2; this scan must become a new signed direct-child bundle.",
+        "Provider configuration and public state are action-time prerequisites, not facts established by offline source review.",
+        "The server has no telemetry sink, but npm/npx bootstrap may contact npm and the MCP client may process returned results elsewhere.",
+        "Redacted and aggregate search still decode and index searchable content internally; privacy constrains output while the index remains process-memory-only and bounded."
       ],
       "attackerCapabilities": [
-        "An MCP caller may supply schema-valid tool arguments, query text, cursors, references, modes, and partial-result options but does not control startup secrets or host files.",
-        "A party reaching loopback HTTP without the token may supply headers and a bounded authorization candidate but must be rejected before body parsing.",
-        "An authenticated HTTP caller receives only the configured privacy ceiling; there is no per-client identity or multi-tenant authorization.",
-        "A copied-database provider may control schema values, message blobs, identifiers, attachment strings, and sidecar bytes but not operator secrets, live Contacts, fixed executables, or release authority.",
-        "A repository contributor may influence source and workflows but is not assumed to control signing keys, protected environments, OIDC mappings, registry accounts, or tag protection."
+        "An MCP caller may submit schema-valid tool arguments, query text, cursors, references, modes, dates, search scopes, and partial-result options, and receives only data permitted by the startup ceiling.",
+        "A party reaching loopback HTTP without the token may submit bounded headers and an authorization candidate but must be rejected before body parsing.",
+        "Possession of the single HTTP token grants the configured capability; there is no per-client identity, tenant isolation, OAuth, or distinct token scope.",
+        "A copied-database provider may control SQLite values, blobs, identifiers, filenames, paths, and sidecars but not operator secrets, live Contacts, fixed helpers, or release authority.",
+        "A same-account process capable of adversarial path replacement is outside the supported copy boundary; stable symlink, hard-link, and main/WAL aliases are checked.",
+        "A repository contributor may alter source and workflows but is not assumed to control signing keys, protected environments, OIDC mappings, registry identities, or protected tags.",
+        "The downstream MCP client controls retention and further processing after results cross the MCP boundary."
       ],
       "securityObjectives": [
-        "Keep every 2.x tool read-only and exclude message sending, mutation, watchers, stateful sessions, and bulk dump APIs.",
-        "Fail closed on unsupported schema, changed database state, decoding failures, query budgets, copy/live aliasing, and cursor-lineage mismatches.",
-        "Authenticate HTTP before body parsing, bind only loopback, and enforce authority, size, rate, concurrency, and timeout limits.",
-        "Prevent privacy relaxation above startup policy and exclude forbidden identities, content, paths, references, and exact timestamps from stricter modes.",
-        "Keep decoded search data memory-only and bound native decoding, query work, worker lifetime, package content, and diagnostics.",
-        "Bind every public package to reviewed source, complete zero-finding evidence, exact bytes, protected provenance, and version-aligned public metadata."
+        "Keep every 2.x tool read-only and exclude sending, mutation, dump/export, watchers, subscriptions, stateful HTTP sessions, and persistent message indexes.",
+        "Resolve live and copied database sources safely, reject copy/live aliases, preserve snapshots, lineages, and frozen traversals, and fail closed on unsupported schema or change.",
+        "Never pair copied Messages data with live Contacts, never guess ambiguous contacts, and preserve unknown service attribution.",
+        "Prevent privacy relaxation and remove forbidden content, identities, paths, references, and exact timestamps from stricter outputs.",
+        "Keep decoded search state memory-only and bound source cardinality, native IPC, worker lifetime, query/HTTP work, and result size.",
+        "Use fixed packaged native helpers with no shell, bounded IPC and environments, decoder self-test, class allowlisting, and no object-constructing legacy deserializer.",
+        "Load each secret from one direct or file source; require operator-owned 0600 no-follow regular files and independent reference/database secrets.",
+        "Authenticate HTTP before parsing, bind loopback, validate Host/Origin, and enforce resource limits.",
+        "Bind beta.2 to a fresh signed evidence child of 4f68be639b4963538c2ff474ef82fe3b292130af and publish identical attested bytes and aligned metadata everywhere."
       ],
-      "summary": "imessage-mcp 2.0.0-beta.1 is a macOS-only, read-only MCP that exposes Apple Messages history through local stdio or authenticated loopback HTTP. Both transports share a bounded two-worker runtime that opens one live or copied Mac chat.db read-only, may read already-authorized unified Contacts for the live source, decodes attributed bodies through a fixed Foundation helper, keeps search data in memory, and enforces a startup privacy ceiling. Publication is a separate privileged path bound to signed source and evidence commits, sealed zero-finding scan artifacts, exact package bytes, protected environments, and OIDC provenance.",
+      "summary": "At signed revision 4f68be639b4963538c2ff474ef82fe3b292130af, imessage-mcp 2.0.0-beta.2 is a macOS-only, read-only MCP server for Apple Messages history. Stdio runs under the launching macOS account and defaults to full disclosure; authenticated HTTP binds only to loopback and defaults to redacted output. Two bounded workers open one live or copied chat.db read-only, may read already-authorized unified Contacts for a live source, decode attributed bodies through fixed Foundation/JXA helpers, and keep searchable decoded content only in a bounded in-memory index. Publication is a separate privileged path requiring signed source and evidence commits, exact-revision zero-finding evidence, protected attestations, exact tarball verification, and independently scoped npm, MCP Registry, and GitHub Release jobs.",
       "trustBoundaries": [
-        "Local MCP client to stdio server: the caller inherits the same macOS account authority and stdio defaults to full disclosure.",
-        "Tailnet or local HTTP client to the loopback server: Tailscale Serve is the operator-owned TLS boundary; the server owns bearer authentication, Host/Origin validation, method and body validation, rates, concurrency, deadlines, and response limits.",
-        "Server workers to Apple Messages SQLite: selected files are canonicalized and identity-checked before readonly/fileMustExist SQLite opens, query_only is enabled, and requests use bounded read snapshots.",
-        "Live source versus copied source: copy mode cannot resolve to this account's live database or WAL through stable path aliases or device/inode identity; copied inputs must remain operator-controlled and unchanged.",
-        "Workers to fixed native Contacts and Foundation decoder helpers: absolute executables and packaged scripts, no shell, minimal environment, bounded IPC, deadlines, and class allowlists.",
-        "Tool implementation to MCP result: strict schemas, seven registered read-only tools, privacy projection, forbidden-field assertions, bounded summaries, and redacted diagnostics.",
-        "Source revision to public release: signed direct-child evidence, exactly three canonical scan files, protected attestations, exact tarball verification, OIDC publication, and stable-only canary proof."
+        "Local MCP client to stdio: same macOS account and inherited Full Disk Access; stdio defaults to full disclosure and has bounded input.",
+        "Local or tailnet client to HTTP: loopback bind, authentication before body parsing, Host/Origin checks, POST /mcp only, and bounded headers, bodies, responses, sockets, rates, concurrency, and deadlines; Tailscale remains operator-owned.",
+        "CLI or same-authority embedding caller to runtime: CLI enforces source, Contacts, transport, privacy, secret, and attachment invariants; direct embedding must preserve RuntimeConfig cross-field invariants.",
+        "Workers to Messages SQLite: canonical and identity-pinned source; copy aliases to live main/WAL rejected before open; readonly, fileMustExist, query_only, deferred snapshots, and fail-closed change detection.",
+        "Copied archive provider to server: schema values, bodies, identifiers, relationships, paths, and sidecars are untrusted; live Contacts are disabled and the operator must keep the archive stable.",
+        "Workers to fixed Contacts and Foundation helpers: absolute executable, packaged scripts, no shell, bounded IPC, deadlines, decoder serialization, output validation, and keyed-archive class allowlist.",
+        "Full internal result to MCP caller: startup ceiling, privacy projection, and forbidden-field assertions precede structuredContent and text; outputs and metadata-only diagnostics are bounded.",
+        "Source to public package: signed direct-child evidence changes only three canonical scan files; protected workflows attest exact bytes and independently authorize npm OIDC, Registry OIDC, and GitHub Release."
       ]
     }
   },

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/anipotts/imessage-mcp",
     "source": "github"
   },
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "imessage-mcp",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "transport": {
         "type": "stdio"
       },

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -180,12 +180,54 @@ describe("native and release hardening", () => {
     expect(npmJob.match(/gh attestation verify/gu)).toHaveLength(3);
     expect(npmJob.indexOf("gh attestation verify")).toBeLessThan(npmJob.indexOf("npm publish"));
     expect(npmJob.indexOf("attest-canary.yml")).toBeLessThan(npmJob.indexOf("--tag latest"));
+    const publicNpm = release.slice(release.indexOf("  verify-public-npm:"), release.indexOf("  publish-registry:"));
+    expect(publicNpm).toContain("--omit=dev");
     const registry = release.slice(release.indexOf("  publish-registry:"), release.indexOf("  publish-github-release:"));
     expect(registry).toContain("contents: read");
     expect(registry).toContain("id-token: write");
     expect(registry).not.toContain("contents: write");
     expect(registry).toContain("persist-credentials: false");
-    const github = release.slice(release.indexOf("  publish-github-release:"));
+    const github = release.slice(release.indexOf("  publish-github-release:"), release.indexOf("  resume-verify-public-npm:"));
+    expect(github).toContain("contents: write");
+    expect(github).not.toContain("id-token: write");
+    expect(github).not.toContain("mcp-publisher");
+  });
+
+  it("resumes a partial release without republishing npm or weakening split authority", () => {
+    const release = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+    const recovery = release.slice(release.indexOf("  resume-verify-public-npm:"));
+    const verify = recovery.slice(0, recovery.indexOf("  resume-publish-registry:"));
+    const registry = recovery.slice(
+      recovery.indexOf("  resume-publish-registry:"),
+      recovery.indexOf("  resume-publish-github-release:"),
+    );
+    const github = recovery.slice(
+      recovery.indexOf("  resume-publish-github-release:"),
+      recovery.indexOf("  resume-verify-public-surfaces:"),
+    );
+
+    expect(release).toContain("workflow_dispatch:");
+    expect(recovery).not.toContain("npm publish");
+    expect(verify).toContain("environment: security-attestation");
+    expect(verify).toContain('test "$GITHUB_REF" = "refs/heads/main"');
+    expect(verify).toContain('verify-commit "$EVIDENCE_COMMIT"');
+    expect(verify).toContain('verify-tag "v${TARGET_VERSION}"');
+    expect(verify).toContain('"publish verified npm artifact",');
+    expect(verify).toContain('jobs.get(name) !== "success"');
+    expect(verify).toContain('jobs.get("verify public npm installation") !== "failure"');
+    expect(verify).toContain("--source-digest \"$EVIDENCE_COMMIT\"");
+    expect(verify).toContain("scripts/security-evidence.ts verify");
+    expect(verify).toContain('workflow.path !== ".github/workflows/release.yml"');
+    expect(verify).toContain("--omit=dev");
+    expect(verify).toContain("audit signatures");
+
+    expect(registry).toContain("environment: mcp-registry-release");
+    expect(registry).toContain("id-token: write");
+    expect(registry).toContain("contents: read");
+    expect(registry).not.toContain("contents: write");
+    expect(registry).toContain("login github-oidc");
+
+    expect(github).toContain("environment: github-release");
     expect(github).toContain("contents: write");
     expect(github).not.toContain("id-token: write");
     expect(github).not.toContain("mcp-publisher");

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -208,6 +208,8 @@ describe("native and release hardening", () => {
 
     expect(release).toContain("workflow_dispatch:");
     expect(recovery).not.toContain("npm publish");
+    expect(recovery).not.toContain("ref: ${{ inputs.evidence_commit }}");
+    expect(recovery).not.toContain("ref: ${{ needs.resume-verify-public-npm.outputs.evidence_commit }}");
     expect(verify).toContain("environment: security-attestation");
     expect(verify).toContain('test "$GITHUB_REF" = "refs/heads/main"');
     expect(verify).toContain('verify-commit "$EVIDENCE_COMMIT"');
@@ -219,6 +221,9 @@ describe("native and release hardening", () => {
     expect(verify).toContain("scripts/security-evidence.ts verify");
     expect(verify).toContain('workflow.path !== ".github/workflows/release.yml"');
     expect(verify).toContain("--omit=dev");
+    expect(verify).toContain("--ignore-scripts");
+    expect(verify).toContain("src/verify-installed-graph.ts");
+    expect(verify).not.toContain("package/dist/verify-installed-graph.js");
     expect(verify).toContain("audit signatures");
 
     expect(registry).toContain("environment: mcp-registry-release");

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -175,6 +175,8 @@ describe("native and release hardening", () => {
       .not.toMatch(/npm run (?:verify|test:performance)/u);
     const npmJob = release.slice(release.indexOf("  publish-npm:"), release.indexOf("  verify-public-npm:"));
     expect(npmJob).toContain("attestations: read");
+    expect(npmJob).toContain('TARBALL="./release-artifact/${{ needs.verify-release.outputs.tarball }}"');
+    expect(npmJob).toContain('test -f "$TARBALL"');
     expect(npmJob.match(/gh attestation verify/gu)).toHaveLength(3);
     expect(npmJob.indexOf("gh attestation verify")).toBeLessThan(npmJob.indexOf("npm publish"));
     expect(npmJob.indexOf("attest-canary.yml")).toBeLessThan(npmJob.indexOf("--tag latest"));

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -223,8 +223,8 @@ describe("native and release hardening", () => {
     expect(verify).toContain("scripts/security-evidence.ts verify");
     expect(verify).toContain('workflow.path !== ".github/workflows/release.yml"');
     expect(verify).toContain("--omit=dev");
-    expect(verify).toContain("--ignore-scripts");
     expect(verify).toContain("src/verify-installed-graph.ts");
+    expect(verify).toContain('node_modules/.bin/imessage-mcp" --version');
     expect(verify).not.toContain("package/dist/verify-installed-graph.js");
     expect(verify).toContain("audit signatures");
 

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -216,7 +216,9 @@ describe("native and release hardening", () => {
     expect(verify).toContain('verify-tag "v${TARGET_VERSION}"');
     expect(verify).toContain('"publish verified npm artifact",');
     expect(verify).toContain('jobs.get(name) !== "success"');
-    expect(verify).toContain('jobs.get("verify public npm installation") !== "failure"');
+    expect(verify).toContain('["failure", "skipped", "skipped"]');
+    expect(verify).toContain('["success", "failure", "skipped"]');
+    expect(verify).toContain('["success", "success", "failure"]');
     expect(verify).toContain("--source-digest \"$EVIDENCE_COMMIT\"");
     expect(verify).toContain("scripts/security-evidence.ts verify");
     expect(verify).toContain('workflow.path !== ".github/workflows/release.yml"');

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -191,6 +191,10 @@ describe("native and release hardening", () => {
     expect(github).toContain("contents: write");
     expect(github).not.toContain("id-token: write");
     expect(github).not.toContain("mcp-publisher");
+    expect(github).toContain("draft: true");
+    expect(github).toContain('gh release edit "v${VERSION}"');
+    expect(github).toContain("!release.immutable");
+    expect(github).toContain("gh release verify-asset");
   });
 
   it("resumes a partial release without republishing npm or weakening split authority", () => {
@@ -238,6 +242,12 @@ describe("native and release hardening", () => {
     expect(github).toContain("contents: write");
     expect(github).not.toContain("id-token: write");
     expect(github).not.toContain("mcp-publisher");
+    expect(github).toContain("draft: true");
+    expect(github).toContain('process.stdout.write("draft")');
+    expect(github).toContain('gh release edit "v${VERSION}"');
+    expect(github).toContain("!release.immutable");
+    expect(github).toContain("gh release verify-asset");
+    expect(github).not.toContain("--method DELETE");
   });
 
   it("binds security evidence to canonical scan files whose exact parent was scanned", () => {


### PR DESCRIPTION
## what changed\n\n- advances the unpublished prerelease to 2.0.0-beta.2\n- publishes the verified tarball through an explicit local ./release-artifact path\n- adds regression coverage for npm path parsing\n- attaches a fresh complete zero-finding scan of the exact signed beta.2 source\n\n## why\n\nThe beta.1 release workflow passed source, package, secret, and CodeQL gates but npm interpreted the relative tarball string as GitHub shorthand. No beta.1 package was uploaded. The protected tag and failed run remain immutable evidence, so the correction advances to beta.2.\n\n## verification\n\n- full npm verification passed on Node 22, 24, and 26\n- 110 tests passed\n- installed tarball, all seven tools, stdio, authenticated HTTP, and named-client checks passed\n- dependency audit and whole-tree secret scan passed\n- one-million-message performance and memory ceilings passed\n- exact local npm publish dry run passed\n- Codex Security scan fa2751e9-81f8-4821-a867-d58388af08a9 covered all 81 tracked files with zero findings\n- signed evidence commit adabc490 changes only the three canonical scan files\n\n## release state\n\nUnpublished. The beta.2 tag will be created only after pull-request checks and the protected exact-SHA security attestation pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package and server metadata to version **2.0.0-beta.2**.
  * Updated installation and configuration examples for the new version.

* **Bug Fixes**
  * Improved trusted publication by validating the local release artifact before uploading it, preventing incorrect repository interpretation.

* **Security**
  * Refreshed security scan results and verification records for the beta.2 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->