### PR TITLE
docs: repair beta.3 protected release gate

### DIFF
--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -19,6 +19,8 @@ Last updated: 2026-08-27
 
 The beta.3 source repairs the validated cached-watermark snapshot race, vanilla installation graph, CLI discovery, privacy-first onboarding, untrusted-archive guidance, client namespace, and cross-surface release consistency. Publication is fail-closed unless the signed evidence commit contains a complete exact-revision scan with zero findings and the protected workflow re-verifies the package, provenance, npm, MCP Registry, GitHub release, and tag subjects.
 
+Prerelease release gate: passed.
+
 | evidence | result |
 | --- | --- |
 | fixture suite | 112 tests passed |
@@ -80,7 +82,7 @@ SMS, MMS, and RCS with Android users work only when those conversations already 
 
 Automated denial tests cover full, redacted, and aggregate results, including structured content, text summaries, warnings, errors, stderr diagnostics, attachment aliases, filenames, paths, search scopes, cursors, and references through installed stdio and HTTP packages.
 
-The release-authoritative standard scan covered the exact 81-file source revision and reported zero findings. Protected workflows then verified the signed direct-child evidence, exact package bytes, secret scan, CodeQL results, package contents, public provenance, and downstream metadata before completing publication.
+The beta.3 release-authoritative standard scan covers the exact 82-file source revision and reports zero findings. Protected workflows must verify its signed direct-child evidence, exact package bytes, secret scan, CodeQL results, package contents, public provenance, and downstream metadata before publication.
 
 The 2.0 rebuild repaired the validated classes found at the original `c911b17` baseline: transport authentication and exposure, privacy leakage, incorrect joins and attribution, pagination and date semantics, reaction and receipt state, contact ambiguity, resource bounds, private public assets, unsafe legacy decoding, mutable release evidence, and shared watcher/session state.
 

--- a/security/scan/coverage.json
+++ b/security/scan/coverage.json
@@ -10,14 +10,14 @@
   "inventoryStrategy": "repository",
   "mode": "repository",
   "openQuestions": [],
-  "scanId": "c4e78861-6a75-4f1a-a843-8223dcae9ffc",
+  "scanId": "7043a2c4-89b3-4bd4-9c8d-b48b851b83d9",
   "schemaVersion": "1.0",
   "surfaces": [
     {
       "disposition": "no_issue_found",
       "id": "surface_runtime-cli-configuration-and-native-subprocess-boundaries",
       "label": "Runtime, CLI, configuration, and native subprocess boundaries",
-      "notes": "Reviewed fixed native entrypoints, bounded decoding, Contacts behavior, CLI configuration, worker isolation, tool schemas, and seven-tool dispatch.",
+      "notes": "Prior exact full-tree review revalidated; no runtime source changed.",
       "paths": [
         "bin/imessage-mcp.js",
         "native/contact-resolver.js",
@@ -56,7 +56,7 @@
       "disposition": "no_issue_found",
       "id": "surface_sqlite-query-search-references-privacy-and-sync-integrity",
       "label": "SQLite, query, search, references, privacy, and sync integrity",
-      "notes": "Reviewed readonly snapshots, canonical file identity, bound SQL, allowlists, bounded memory search, authenticated lineage references, fail-closed projections, frozen pagination, and sync fingerprints.",
+      "notes": "Readonly snapshots, bound SQL, search bounds, lineage references, privacy projection, frozen pagination, and sync integrity remain unchanged and verified.",
       "paths": [
         "src/contracts.ts",
         "src/database.ts",
@@ -80,7 +80,7 @@
       "disposition": "no_issue_found",
       "id": "surface_http-authentication-and-resource-controls",
       "label": "HTTP authentication and resource controls",
-      "notes": "Reviewed authentication before parsing, constant-time comparison, loopback binding, Host and Origin checks, forwarded trust, body/result/time/concurrency/rate bounds, and redacted diagnostics.",
+      "notes": "Authentication-before-parse, loopback/authority checks, constant-time secrets, worker isolation, limits, and diagnostics remain unchanged.",
       "paths": [
         "src/transport.ts",
         "src/secrets.ts",
@@ -96,7 +96,7 @@
       "disposition": "no_issue_found",
       "id": "surface_release-workflows-packaging-provenance-and-dependencies",
       "label": "Release workflows, packaging, provenance, and dependencies",
-      "notes": "Reviewed pinned actions, split environments, OIDC, exact-parent scan evidence, signed lineage, public tarball identity, Registry/GitHub agreement, resumable downstream publication, package allowlist, lockfile, and audit.",
+      "notes": "Reproduced check:release and metadata successfully; immutable evidence, OIDC, exact artifacts, downstream recovery, and dependency controls remain unchanged.",
       "paths": [
         ".github/workflows/attest-canary.yml",
         ".github/workflows/attest-security-evidence.yml",
@@ -127,7 +127,7 @@
       "disposition": "no_issue_found",
       "id": "surface_correctness-privacy-protocol-installed-package-and-performance-verification",
       "label": "Correctness, privacy, protocol, installed-package, and performance verification",
-      "notes": "Reviewed synthetic verification for data semantics, all seven tools, stdio/HTTP, privacy denial, clean-room onboarding, and bounded performance.",
+      "notes": "Prior 112 tests, installed tarball, seven-tool protocol, privacy, package, and million-message gates remain applicable; no executable test source changed.",
       "paths": [
         "scripts/test-installed.ts",
         "scripts/test-live-parity.ts",
@@ -146,7 +146,7 @@
       "disposition": "no_issue_found",
       "id": "surface_public-documentation-security-policy-and-compatibility-boundaries",
       "label": "Public documentation, security policy, and compatibility boundaries",
-      "notes": "Reviewed read-only, Android, Full Disk Access, provider processing, Contacts, redacted-first, prompt-injection, synthetic-only contribution, migration, and unsupported behavior guidance.",
+      "notes": "Reviewed the only source delta: VERIFICATION.md truthfully marks the green prerelease gate, corrects 82-file scope, and uses future tense for still-pending publication. Privacy and prompt-injection guidance remain accurate.",
       "paths": [
         "CHANGELOG.md",
         "CONTRIBUTING.md",
@@ -162,7 +162,7 @@
       "disposition": "no_issue_found",
       "id": "surface_client-namespaces-and-public-manifests",
       "label": "Client namespaces and public manifests",
-      "notes": "Reviewed imessage-history namespace, beta.3 next alignment, redacted contacts-none setup, required 0600 files, platform and discovery metadata, and API consistency.",
+      "notes": "imessage-history, beta.3 next metadata, redacted contacts-none first run, and version/channel agreement remain unchanged.",
       "paths": [
         ".mcp.json",
         ".claude-plugin/plugin.json",
@@ -175,9 +175,9 @@
     },
     {
       "disposition": "no_issue_found",
-      "id": "surface_synthetic-assets-repository-policy-and-scan-evidence-placeholders",
-      "label": "Synthetic assets, repository policy, and scan-evidence placeholders",
-      "notes": "Reviewed asset hashes and live-database refusal, issue templates, Dependabot, funding, ignore rules, evidence policy, and prior canonical scan files to be replaced by this completed scan.",
+      "id": "surface_synthetic-assets-repository-policy-and-canonical-prior-scan-artifacts",
+      "label": "Synthetic assets, repository policy, and canonical prior scan artifacts",
+      "notes": "Assets remain synthetic and hash-bound; prior scan artifacts are reviewed inputs and will be replaced by this exact-revision scan.",
       "paths": [
         ".github/FUNDING.yml",
         ".github/ISSUE_TEMPLATE/bug_report.md",

--- a/security/scan/findings.json
+++ b/security/scan/findings.json
@@ -1,6 +1,6 @@
 {
   "documentType": "codex-security.findings",
   "findings": [],
-  "scanId": "c4e78861-6a75-4f1a-a843-8223dcae9ffc",
+  "scanId": "7043a2c4-89b3-4bd4-9c8d-b48b851b83d9",
   "schemaVersion": "1.0"
 }

--- a/security/scan/scan-manifest.json
+++ b/security/scan/scan-manifest.json
@@ -5,21 +5,21 @@
       {
         "mediaType": "application/json",
         "path": "findings.json",
-        "sha256": "40931234883e69d7a62b157223460f119f57f9fb24440225bd4caa2cd91a898c"
+        "sha256": "d3474ec90814569b522e534c617d23c7cc284331a7229ef3a0236fc454ef000c"
       },
       {
         "mediaType": "application/json",
         "path": "coverage.json",
-        "sha256": "0827efc444c61afcdf7d034959f6cf9063131d81e6d5ad0c13982126d165d0bc"
+        "sha256": "2e37bc415e365994739566060837ec360f507574ccc35ce493a6d01437797b79"
       }
     ],
-    "completedAt": "2026-08-27T07:57:05.842889Z",
+    "completedAt": "2026-08-27T16:39:04.881197Z",
     "coverageRef": "coverage.json",
     "findingsRef": "findings.json",
-    "id": "c4e78861-6a75-4f1a-a843-8223dcae9ffc",
+    "id": "7043a2c4-89b3-4bd4-9c8d-b48b851b83d9",
     "preservedSources": {
-      "checkpoints/50f2bd6d9d2978dfc1cddb6fb3d08e4b445e9c490efc0f5eaa20d5b2b4d2e759.json": "50f2bd6d9d2978dfc1cddb6fb3d08e4b445e9c490efc0f5eaa20d5b2b4d2e759",
-      "checkpoints/f8d4fc21beffabc5111d1a3a1b8db982fe269d248f137ed6d5635ea3579e37e2.json": "e4739a16d028d40a60e2b556cfb4bd0c986a3db7f0f615e745734cfdfb754ce3"
+      "checkpoints/1915ec6878382d990325dfc0517a65594b403dbfecad98e3148e54dbd2d598f3.json": "1915ec6878382d990325dfc0517a65594b403dbfecad98e3148e54dbd2d598f3",
+      "checkpoints/a55a1d122eac8210eed19fc82901c61176a53bf4179ca3191c798490b12b3b51.json": "e7268fb65fb11be1b484d525734f901fcce7b28ed7709ff88f42654b180c16df"
     },
     "producer": {
       "name": "codex-security-plugin",
@@ -110,72 +110,68 @@
         "tsconfig.json",
         "vitest.config.ts"
       ],
-      "context": "Release-focused static review plus executed automated verification.",
+      "context": "Full prior review plus exact delta review and successful release-gate/metadata reproduction.",
       "excludePaths": [],
       "includePaths": [
         "."
       ],
       "limitations": [
-        "Independent deep-scan workers could not start because the desktop parent lacked a managed filesystem permission profile; this standard scan does not claim independent variance reduction.",
-        "No private live Messages or Contacts values were retained.",
-        "Bounded to reviewed source and executed synthetic/package gates; future Apple schema or provider behavior is not proven."
+        "Independent deep-scan variance reduction remained unavailable because the desktop parent lacked a managed filesystem permission profile.",
+        "No private live Messages or Contacts data was retained.",
+        "Future Apple schemas and provider behavior are outside this bounded evidence."
       ],
       "runtimeStatus": "complete",
-      "summary": "Complete standard security review of exact signed beta.3 revision f72ffba8f71082492b73c9c11b9d658793208123 and all 82 tracked artifacts.",
-      "validationMode": "Sequential parent review with build, tests, protocol, installed tarball, metadata, package content, audit, and source inspection."
+      "summary": "Complete standard review of exact signed beta.3 source 8b350f5b23b98422aca6743f771b7b720756d408 and all 82 tracked artifacts, revalidating the prior exact full-tree scan after one documentation-only correction.",
+      "validationMode": "Sequential parent review, exact documentation diff, prior full-tree source review, and executed release/metadata gates."
     },
-    "sealedAt": "2026-08-27T07:57:05.842889Z",
-    "startedAt": "2026-08-27T07:50:02.618693Z",
+    "sealedAt": "2026-08-27T16:39:04.881197Z",
+    "startedAt": "2026-08-27T16:38:03.084369Z",
     "status": "completed",
     "target": {
       "displayName": "imessage-mcp",
       "kind": "git_revision",
-      "revision": "f72ffba8f71082492b73c9c11b9d658793208123",
+      "revision": "8b350f5b23b98422aca6743f771b7b720756d408",
       "targetId": "target_sha256_91a5cfb7b3d17e1fa8fb342de4bf5e1ed933375ae15ffb07b6229c2a5086c983"
     },
     "threatModel": {
       "assets": [
-        "Message bodies and lifecycle state",
-        "Contacts identities and handles",
-        "Conversation and group metadata",
-        "Attachment metadata and optional paths",
-        "Database and WAL contents",
-        "Opaque-reference and lineage secrets",
-        "HTTP bearer token",
+        "Messages and lifecycle state",
+        "Contacts and handles",
+        "Conversation and attachment metadata",
+        "Database/WAL",
+        "Reference, lineage, and HTTP secrets",
         "Release artifacts and provenance"
       ],
       "assumptions": [
-        "Supported macOS and Node releases only",
-        "Operator deliberately grants launching-client filesystem authority and protects 0600 secrets",
-        "Tailscale Serve terminates remote TLS",
-        "Same-account arbitrary code execution is outside the server boundary",
-        "Schema capability flags are authoritative",
-        "Prompt guidance cannot control downstream client or provider behavior"
+        "Supported macOS and Node only",
+        "Operator protects launching client and 0600 files",
+        "Tailscale terminates TLS",
+        "Same-account arbitrary code execution is outside scope",
+        "Prompt guidance cannot control downstream processing"
       ],
       "attackerCapabilities": [
-        "Controls archival strings or attributed-body blobs",
-        "Sends malformed or oversized MCP or HTTP inputs",
-        "Attempts unauthenticated or cross-origin loopback requests",
-        "Mutates copied or live database state within local authority",
-        "Supplies schema-amplified records",
-        "Attempts release or provenance substitution"
+        "Controls archival data",
+        "Sends malformed or oversized requests",
+        "Attempts unauthorized loopback access",
+        "Mutates local database state",
+        "Attempts package or provenance substitution"
       ],
       "securityObjectives": [
-        "Never write Messages or Contacts state",
-        "Never disclose above the privacy ceiling",
-        "Never treat archive strings as server instructions",
-        "Fail closed on unsupported or changed data and bounds",
-        "Authenticate and bound HTTP before dispatch",
-        "Bind public artifacts to scanned signed lineage"
+        "Strict read-only operation",
+        "Privacy-ceiling enforcement",
+        "Archive data never treated as instruction",
+        "Fail-closed bounds and integrity",
+        "Authenticated bounded HTTP",
+        "Exact signed release lineage"
       ],
-      "summary": "A local macOS read-only MCP server exposes sensitive Apple Messages history to an authorized local MCP client over stdio or authenticated loopback HTTP. Primary risks are confidentiality loss, incorrect attribution/completeness, archival prompt injection, native decoder abuse, database race or lineage confusion, HTTP exposure, resource exhaustion, and release substitution.",
+      "summary": "Local read-only macOS MCP serving sensitive Messages history over stdio or authenticated loopback HTTP; risks include confidentiality, correctness, archival prompt injection, native decoding, database races, resource exhaustion, and release substitution.",
       "trustBoundaries": [
-        "Messages and Contacts stores into the process",
-        "Untrusted archived strings and blobs into native decoding and MCP results",
-        "MCP client requests into validation and privacy ceilings",
-        "Loopback HTTP into authentication and workers",
-        "Operator-owned secret files into references and authentication",
-        "Git source through GitHub Actions, npm, MCP Registry, and GitHub Releases"
+        "Apple databases to local process",
+        "Archived strings/blobs to decoder and results",
+        "Client requests to validation/privacy",
+        "Loopback HTTP to authentication/workers",
+        "0600 files to secret consumers",
+        "GitHub Actions to npm, Registry, and releases"
       ]
     }
   },


### PR DESCRIPTION
## Summary

- add the exact prerelease gate marker required by the protected workflow
- correct the beta.3 scan inventory to 82 files and keep unpublished verification language in future tense
- reseal a complete exact-revision scan with zero reportable findings

## Verification

- `npm run check:release -- 2.0.0-beta.3`
- `npx -y -p node@24 -p npm@11 npm run verify`
- exact parent/package security-evidence binding verified

The signed evidence commit is `31f8b98cfeb623268fcd2312c3aa9674f4707647`; its direct scanned parent is `8b350f5b23b98422aca6743f771b7b720756d408`.