### PR TITLE
Release imessage-mcp 2.0.0-rc.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "imessage-mcp",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-rc.1",
   "description": "Read-only MCP for iMessage, SMS, MMS, and RCS history already present in Apple Messages on Mac.",
   "author": {
     "name": "Ani Potts",

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "imessage-history": {
       "command": "npx",
-      "args": ["-y", "imessage-mcp@2.0.0-beta.3", "--contacts", "none", "--privacy", "redacted"],
+      "args": ["-y", "imessage-mcp@2.0.0-rc.1", "--contacts", "none", "--privacy", "redacted"],
       "env": {
         "IMESSAGE_REFERENCE_KEY_FILE": "${HOME}/.imessage-mcp-reference-key",
         "IMESSAGE_DATABASE_ID_FILE": "${HOME}/.imessage-mcp-database-id"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.0-rc.1] - 2026-08-27
+
+- Promotes the accepted seven-tool read-only API to its first release candidate.
+- Makes privacy-first `--contacts none` diagnostics pass explicitly instead of showing an expected warning.
+- Clarifies the version-pinned first run and fail-closed search recovery without requiring a global install.
+
 ## [2.0.0-beta.3] - 2026-08-27
 
 - Pinned every SQLite request snapshot before validating cached cursor watermarks, with a deterministic concurrent-WAL regression.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Confirm a supported Node major, then verify the exact prerelease. No global inst
 
 ```sh
 node --version
-npx -y imessage-mcp@2.0.0-beta.3 --version
+npx -y imessage-mcp@2.0.0-rc.1 --version
 ```
 
 Create two independent operator-owned secret files:
@@ -52,7 +52,7 @@ openssl rand -base64 32 > "$HOME/.imessage-mcp-reference-key"
 openssl rand -base64 32 > "$HOME/.imessage-mcp-database-id"
 export IMESSAGE_REFERENCE_KEY_FILE="$HOME/.imessage-mcp-reference-key"
 export IMESSAGE_DATABASE_ID_FILE="$HOME/.imessage-mcp-database-id"
-npx -y imessage-mcp@2.0.0-beta.3 doctor --contacts none --privacy redacted
+npx -y imessage-mcp@2.0.0-rc.1 doctor --contacts none --privacy redacted
 ```
 
 The files must remain regular, non-symlink files owned by the operator with mode `0600`. If `doctor` reports `database_read` or `wal_read`, grant Full Disk Access to the application or shell that launched that exact process, restart it, and rerun the same command. If it reports `node`, use Node 22, 24, or 26. If it reports `reference_key` or `database_id`, confirm the exported paths and file modes. Other failures include precise remediation in the matching check.
@@ -64,7 +64,7 @@ Register the server as `imessage-history`, start with handles-only Contacts and 
   "mcpServers": {
     "imessage-history": {
       "command": "npx",
-      "args": ["-y", "imessage-mcp@2.0.0-beta.3", "--contacts", "none", "--privacy", "redacted"],
+      "args": ["-y", "imessage-mcp@2.0.0-rc.1", "--contacts", "none", "--privacy", "redacted"],
       "env": {
         "IMESSAGE_REFERENCE_KEY_FILE": "/Users/you/.imessage-mcp-reference-key",
         "IMESSAGE_DATABASE_ID_FILE": "/Users/you/.imessage-mcp-database-id"
@@ -107,7 +107,7 @@ Set a stricter ceiling at startup:
   "mcpServers": {
     "imessage-history": {
       "command": "npx",
-      "args": ["-y", "imessage-mcp@2.0.0-beta.3", "--contacts", "none", "--privacy", "redacted"],
+      "args": ["-y", "imessage-mcp@2.0.0-rc.1", "--contacts", "none", "--privacy", "redacted"],
       "env": {
         "IMESSAGE_REFERENCE_KEY_FILE": "/Users/you/.imessage-mcp-reference-key",
         "IMESSAGE_DATABASE_ID_FILE": "/Users/you/.imessage-mcp-database-id"
@@ -148,7 +148,7 @@ Add the server through Codex MCP settings or the CLI:
 ```sh
 codex mcp add --env IMESSAGE_REFERENCE_KEY_FILE="$HOME/.imessage-mcp-reference-key" \
   --env IMESSAGE_DATABASE_ID_FILE="$HOME/.imessage-mcp-database-id" \
-  imessage-history -- npx -y imessage-mcp@2.0.0-beta.3 --contacts none --privacy redacted
+  imessage-history -- npx -y imessage-mcp@2.0.0-rc.1 --contacts none --privacy redacted
 ```
 
 Grant Full Disk Access to the Codex application that launches the process, then restart that application.
@@ -162,7 +162,7 @@ Add this entry to Claude Desktop's MCP configuration:
   "mcpServers": {
     "imessage-history": {
       "command": "npx",
-      "args": ["-y", "imessage-mcp@2.0.0-beta.3", "--contacts", "none", "--privacy", "redacted"],
+      "args": ["-y", "imessage-mcp@2.0.0-rc.1", "--contacts", "none", "--privacy", "redacted"],
       "env": {
         "IMESSAGE_REFERENCE_KEY_FILE": "/Users/you/.imessage-mcp-reference-key",
         "IMESSAGE_DATABASE_ID_FILE": "/Users/you/.imessage-mcp-database-id"
@@ -179,7 +179,7 @@ Grant Full Disk Access to Claude Desktop, restart it, and run `server_status`.
 ```sh
 claude mcp add imessage-history -e IMESSAGE_REFERENCE_KEY_FILE="$HOME/.imessage-mcp-reference-key" \
   -e IMESSAGE_DATABASE_ID_FILE="$HOME/.imessage-mcp-database-id" \
-  -- npx -y imessage-mcp@2.0.0-beta.3 --contacts none --privacy redacted
+  -- npx -y imessage-mcp@2.0.0-rc.1 --contacts none --privacy redacted
 ```
 
 ### cursor

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ macOS grants Full Disk Access to the launching MCP client application or shell, 
 
 ## two-minute privacy-first setup
 
-Confirm a supported Node major, then install the exact prerelease:
+Confirm a supported Node major, then verify the exact prerelease. No global install is required; the client configuration below runs this pinned version through `npx`:
 
 ```sh
 node --version
-npm install -g imessage-mcp@2.0.0-beta.3
+npx -y imessage-mcp@2.0.0-beta.3 --version
 ```
 
 Create two independent operator-owned secret files:
@@ -52,7 +52,7 @@ openssl rand -base64 32 > "$HOME/.imessage-mcp-reference-key"
 openssl rand -base64 32 > "$HOME/.imessage-mcp-database-id"
 export IMESSAGE_REFERENCE_KEY_FILE="$HOME/.imessage-mcp-reference-key"
 export IMESSAGE_DATABASE_ID_FILE="$HOME/.imessage-mcp-database-id"
-imessage-mcp doctor --contacts none --privacy redacted
+npx -y imessage-mcp@2.0.0-beta.3 doctor --contacts none --privacy redacted
 ```
 
 The files must remain regular, non-symlink files owned by the operator with mode `0600`. If `doctor` reports `database_read` or `wal_read`, grant Full Disk Access to the application or shell that launched that exact process, restart it, and rerun the same command. If it reports `node`, use Node 22, 24, or 26. If it reports `reference_key` or `database_id`, confirm the exported paths and file modes. Other failures include precise remediation in the matching check.
@@ -75,6 +75,8 @@ Register the server as `imessage-history`, start with handles-only Contacts and 
 ```
 
 Grant Full Disk Access to that launching MCP client and restart it. Make one redacted health request: call `server_status` with `privacy_mode: redacted`. Then try `list_conversations` with `limit: 10` and `privacy_mode: redacted`. A `PRIVACY_RESTRICTED` response means the request asked for more than the configured ceiling. A database error means the launching client still lacks access or Messages has not created the database.
+
+For the first redacted search, use `search_messages` with a small limit. Search fails closed if an unsupported archived body is encountered. If it returns `DECODE_FAILED`, repeat the same request with `allow_partial: true`; the response marks itself partial and reports skipped rows without returning their contents.
 
 This exact version installs the 2.0 prerelease. Upgrade only by explicitly selecting a newer exact version. The stable setup will remain version-pinned so an existing Full Disk Access client never begins executing a different package only because an npm dist-tag moved.
 

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -11,7 +11,7 @@ Last updated: 2026-08-27
 | `1.3.1` | published and verified | npm `latest`, GitHub Release, and MCP Registry agree; a fresh public install reproduced fixes for issues #5 and #6 before they closed |
 | `2.0.0-beta.1` | tagged, not published | npm rejected the relative tarball argument before upload; the signed tag and failed workflow remain immutable historical evidence |
 | `2.0.0-beta.2` | published and verified | npm `next`, MCP Registry, and an immutable GitHub prerelease agree on the signed evidence lineage and exact package |
-| `2.0.0-beta.3` | release subject | npm `next`; current public availability is authoritative at npm, MCP Registry, and the immutable GitHub release |
+| `2.0.0-beta.3` | published and verified | npm `next`, MCP Registry, and the immutable GitHub prerelease agree on the signed evidence lineage and exact package |
 | `2.0.0-rc.1` | not started | requires beta acceptance with no known security, privacy, attribution, completeness, or installation blocker |
 | `2.0.0` | blocked by design gate | requires an unchanged release candidate to pass the seven-day canary |
 
@@ -57,7 +57,7 @@ The first beta.2 workflow published the attested package to npm, then stopped be
 | --- | --- |
 | supported matrix | GitHub-hosted macOS 14, 15, and 26 on Node 22, 24, and 26 passed `npm run verify` |
 | architecture | arm64 full matrix; macOS 26 Intel installed-package smoke passed |
-| fixture suite | 111 tests passed, covering seven-tool semantics, privacy, database lineage, immutable release controls, source aliasing, decoder safety, lifecycle freshness, and package tamper rejection |
+| fixture suite | 112 tests passed, covering seven-tool semantics, privacy, database lineage, immutable release controls, source aliasing, decoder safety, lifecycle freshness, and package tamper rejection |
 | package | 129-file allowlisted tarball passed metadata, doctor, stdio MCP, authenticated HTTP, named-client, and installed dependency-graph checks |
 | static and supply chain | TypeScript, CodeQL for Actions and JavaScript/TypeScript, Gitleaks, package signatures, and dependency audit passed; zero dependency vulnerabilities reported |
 | transport | stdio and authenticated stateless loopback HTTP passed; a local reverse proxy exercised the documented Tailscale Serve boundary without creating a route |

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -12,8 +12,16 @@ Last updated: 2026-08-27
 | `2.0.0-beta.1` | tagged, not published | npm rejected the relative tarball argument before upload; the signed tag and failed workflow remain immutable historical evidence |
 | `2.0.0-beta.2` | published and verified | npm `next`, MCP Registry, and an immutable GitHub prerelease agree on the signed evidence lineage and exact package |
 | `2.0.0-beta.3` | published and verified | npm `next`, MCP Registry, and the immutable GitHub prerelease agree on the signed evidence lineage and exact package |
-| `2.0.0-rc.1` | not started | requires beta acceptance with no known security, privacy, attribution, completeness, or installation blocker |
+| `2.0.0-rc.1` | release subject | npm `next`; publication requires exact-source scan evidence and protected package/provider gates |
 | `2.0.0` | blocked by design gate | requires an unchanged release candidate to pass the seven-day canary |
+
+## `2.0.0-rc.1` release evidence
+
+Beta acceptance completed against the public `2.0.0-beta.3` npm tarball in an isolated projectless Codex task with no repository context. Under Node 24, privacy-first `doctor`, MCP startup and handshake, all seven advertised tools, redacted status and conversation reads, an opaque-reference history read, fail-closed search plus documented partial recovery, and clean shutdown passed. The task emitted no private archive values and changed no Messages, Contacts, Full Disk Access, active client configuration, or Tailscale state.
+
+Fresh bounded live parity on the RC source matched 375 of 375 attributed bodies across iMessage, SMS/MMS, and RCS. All seven tools passed with zero aggregate leakage and no private values emitted. The RC also makes intentional `--contacts none` doctor state a pass, removes redundant global-install guidance, and puts fail-closed search recovery in the first-run path.
+
+Prerelease release gate: passed.
 
 ## `2.0.0-beta.3` release evidence
 
@@ -92,23 +100,23 @@ No stable release claim will use the word complete while a known security or dat
 
 ## performance gates
 
-The mixed-service one-million-message synthetic fixture passed on macOS 26.5 arm64 with Node 24.19.0:
+The mixed-service one-million-message synthetic fixture passed on macOS 26.5 arm64 with Node 24.20.0:
 
 | measurement | result | gate |
 | --- | ---: | ---: |
-| fixture construction | 4.013 s | informational |
-| bounded startup | 7.725 s | informational |
+| fixture construction | 4.119 s | informational |
+| bounded startup | 7.902 s | informational |
 | `server_status` | 3 ms | under 1 s |
 | `list_conversations` | 12 ms | under 1 s |
 | initial `sync_messages` cursor | 1 ms | under 1 s |
-| complete cold index | 22.511 s | under 60 s |
-| warm substring search | 6 ms | under 2 s |
-| one-character substring search | 97 ms | under 2 s |
-| two authenticated HTTP clients | 22 ms | stable and under 2 s |
+| complete cold index | 24.037 s | under 60 s |
+| warm substring search | 8 ms | under 2 s |
+| one-character substring search | 102 ms | under 2 s |
+| two authenticated HTTP clients | 29 ms | stable and under 2 s |
 | index memory | 355,192,832 bytes | at or below 536,870,912 bytes |
-| process RSS delta | 560,545,792 bytes | informational |
+| process RSS delta | 417,611,776 bytes | informational |
 
-The bounded live archive gate passed all seven tools with zero aggregate probe leakage. Cold complete search took 61.981 seconds; `server_status` took 59 ms and `list_conversations` took 9 ms. The fixed million-message fixture owns the 60-second index target. Live archives use the 90-second cold-request ceiling.
+The bounded live archive gate passed all seven tools with zero aggregate probe leakage. Cold complete search took 61.165 seconds; `server_status` took 56 ms and `list_conversations` took 8 ms. The fixed million-message fixture owns the 60-second index target. Live archives use the 90-second cold-request ceiling.
 
 ## client and transport gates
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "subject_version": "2.0.0-beta.3",
+  "subject_version": "2.0.0-rc.1",
   "channel": "next",
   "assets": [
     {

--- a/package-files.json
+++ b/package-files.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "subject_version": "2.0.0-beta.3",
+  "subject_version": "2.0.0-rc.1",
   "channel": "next",
   "expected_paths": [
     ".claude-plugin/plugin.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imessage-mcp",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imessage-mcp",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-rc.1",
       "license": "MIT",
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imessage-mcp",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-rc.1",
   "mcpName": "io.github.anipotts/imessage-mcp",
   "description": "Read-only MCP for iMessage, SMS, MMS, and RCS history in Apple Messages on Mac",
   "author": "Ani Potts",

--- a/release-status.json
+++ b/release-status.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 4,
-  "subject_version": "2.0.0-beta.3",
+  "subject_version": "2.0.0-rc.1",
   "channel": "next",
   "prerelease_ready": true,
   "security_scan": {

--- a/scripts/test-installed.ts
+++ b/scripts/test-installed.ts
@@ -183,13 +183,21 @@ async function main(): Promise<void> {
     const firstRunDatabaseId = path.join(scratch, "doctor-database-id");
     writeFileSync(firstRunReferenceKey, "synthetic-reference-key-".padEnd(48, "x"), { mode: 0o600 });
     writeFileSync(firstRunDatabaseId, "synthetic-database-lineage-".padEnd(48, "x"), { mode: 0o600 });
-    execFileSync(binary, ["doctor", "--database", fixture.databasePath, "--contacts", "none", "--privacy", "redacted", "--json"], {
+    const doctorOutput = execFileSync(binary, ["doctor", "--database", fixture.databasePath, "--contacts", "none", "--privacy", "redacted", "--json"], {
       cwd: install,
       env: cleanEnvironment({
         IMESSAGE_REFERENCE_KEY_FILE: firstRunReferenceKey,
         IMESSAGE_DATABASE_ID_FILE: firstRunDatabaseId,
       }),
       encoding: "utf8",
+    });
+    const doctorResult = JSON.parse(doctorOutput) as {
+      checks: Array<{ name: string; status: string; detail: string }>;
+    };
+    assert.deepEqual(doctorResult.checks.find((check) => check.name === "contacts"), {
+      name: "contacts",
+      status: "pass",
+      detail: "disabled by --contacts none; using handles only",
     });
     await runCleanRoomFirstRequest(binary, fixture, scratch);
     await runStdio(binary, [], fixture);

--- a/security/scan/coverage.json
+++ b/security/scan/coverage.json
@@ -10,14 +10,14 @@
   "inventoryStrategy": "repository",
   "mode": "repository",
   "openQuestions": [],
-  "scanId": "7043a2c4-89b3-4bd4-9c8d-b48b851b83d9",
+  "scanId": "ecdc5ce0-c355-4292-a182-4c5d129e425c",
   "schemaVersion": "1.0",
   "surfaces": [
     {
       "disposition": "no_issue_found",
       "id": "surface_runtime-cli-configuration-and-native-subprocess-boundaries",
       "label": "Runtime, CLI, configuration, and native subprocess boundaries",
-      "notes": "Prior exact full-tree review revalidated; no runtime source changed.",
+      "notes": "Exact current source plus independent baseline review found no reportable write, unsafe subprocess, configuration, or worker boundary.",
       "paths": [
         "bin/imessage-mcp.js",
         "native/contact-resolver.js",
@@ -27,28 +27,13 @@
         "src/config.ts",
         "src/contacts.ts",
         "src/contracts.ts",
-        "src/database.ts",
         "src/decoder.ts",
         "src/errors.ts",
         "src/index.ts",
-        "src/privacy.ts",
-        "src/references.ts",
-        "src/repositories/analytics.ts",
-        "src/repositories/conversations.ts",
-        "src/repositories/message-integrity.ts",
-        "src/repositories/messages.ts",
-        "src/repositories/sync.ts",
-        "src/result.ts",
-        "src/schema-sql.ts",
-        "src/search-index.ts",
         "src/secrets.ts",
-        "src/sender.ts",
-        "src/time.ts",
         "src/tool-local.ts",
         "src/tool-worker.ts",
-        "src/tools.ts",
-        "src/transport.ts",
-        "src/verify-installed-graph.ts"
+        "src/tools.ts"
       ],
       "receiptRefs": []
     },
@@ -56,11 +41,9 @@
       "disposition": "no_issue_found",
       "id": "surface_sqlite-query-search-references-privacy-and-sync-integrity",
       "label": "SQLite, query, search, references, privacy, and sync integrity",
-      "notes": "Readonly snapshots, bound SQL, search bounds, lineage references, privacy projection, frozen pagination, and sync integrity remain unchanged and verified.",
+      "notes": "Readonly snapshots, bound SQL, canonical source checks, index/decoder bounds, lineage references, privacy projection, pagination, and sync integrity were reviewed at exact source.",
       "paths": [
-        "src/contracts.ts",
         "src/database.ts",
-        "src/errors.ts",
         "src/privacy.ts",
         "src/references.ts",
         "src/repositories/analytics.ts",
@@ -80,7 +63,7 @@
       "disposition": "no_issue_found",
       "id": "surface_http-authentication-and-resource-controls",
       "label": "HTTP authentication and resource controls",
-      "notes": "Authentication-before-parse, loopback/authority checks, constant-time secrets, worker isolation, limits, and diagnostics remain unchanged.",
+      "notes": "Loopback binding, auth-before-parse, constant-time token checks, Host/Origin validation, proxy handling, response/log privacy, concurrency, rate, size, and timeout bounds passed review and protocol execution.",
       "paths": [
         "src/transport.ts",
         "src/secrets.ts",
@@ -96,7 +79,7 @@
       "disposition": "no_issue_found",
       "id": "surface_release-workflows-packaging-provenance-and-dependencies",
       "label": "Release workflows, packaging, provenance, and dependencies",
-      "notes": "Reproduced check:release and metadata successfully; immutable evidence, OIDC, exact artifacts, downstream recovery, and dependency controls remain unchanged.",
+      "notes": "Reviewed exact privileged workflows, evidence lineage, OIDC separation, public recovery, stable derivation, package manifests, dependency graph, and version/channel checks. Node 24 verification and audit passed.",
       "paths": [
         ".github/workflows/attest-canary.yml",
         ".github/workflows/attest-security-evidence.yml",
@@ -113,12 +96,8 @@
         "scripts/clean-dist.mjs",
         "scripts/package-manifest.ts",
         "scripts/release-version.ts",
-        "scripts/screenshots.ts",
         "scripts/security-evidence.ts",
-        "scripts/test-installed.ts",
-        "scripts/test-live-parity.ts",
-        "scripts/test-performance.ts",
-        "scripts/test-protocol.ts",
+        "src/verify-installed-graph.ts",
         "server.json"
       ],
       "receiptRefs": []
@@ -127,8 +106,9 @@
       "disposition": "no_issue_found",
       "id": "surface_correctness-privacy-protocol-installed-package-and-performance-verification",
       "label": "Correctness, privacy, protocol, installed-package, and performance verification",
-      "notes": "Prior 112 tests, installed tarball, seven-tool protocol, privacy, package, and million-message gates remain applicable; no executable test source changed.",
+      "notes": "112 tests, seven-tool stdio and authenticated HTTP, installed tarball, clean-room redacted setup, metadata/package content, and zero-advisory gates passed under supported Node 24.",
       "paths": [
+        "scripts/screenshots.ts",
         "scripts/test-installed.ts",
         "scripts/test-live-parity.ts",
         "scripts/test-performance.ts",
@@ -146,7 +126,7 @@
       "disposition": "no_issue_found",
       "id": "surface_public-documentation-security-policy-and-compatibility-boundaries",
       "label": "Public documentation, security policy, and compatibility boundaries",
-      "notes": "Reviewed the only source delta: VERIFICATION.md truthfully marks the green prerelease gate, corrects 82-file scope, and uses future tense for still-pending publication. Privacy and prompt-injection guidance remain accurate.",
+      "notes": "Reviewed archival prompt-injection guidance, Full Disk Access/client-provider boundary, automatic Contacts disclosure and privacy-first contacts-none setup, redacted first run, Android boundary, contribution privacy, comparison policy, and RC evidence claims.",
       "paths": [
         "CHANGELOG.md",
         "CONTRIBUTING.md",
@@ -154,7 +134,8 @@
         "README.md",
         "SECURITY.md",
         "VERIFICATION.md",
-        "docs/ROADMAP-3.0.md"
+        "docs/ROADMAP-3.0.md",
+        "security/README.md"
       ],
       "receiptRefs": []
     },
@@ -162,22 +143,23 @@
       "disposition": "no_issue_found",
       "id": "surface_client-namespaces-and-public-manifests",
       "label": "Client namespaces and public manifests",
-      "notes": "imessage-history, beta.3 next metadata, redacted contacts-none first run, and version/channel agreement remain unchanged.",
+      "notes": "Package/repository retain imessage-mcp while examples use imessage-history; exact RC version, next channel, redacted ceiling, and contacts-none setup agree across public metadata.",
       "paths": [
         ".mcp.json",
         ".claude-plugin/plugin.json",
         "server.json",
         "package.json",
         "release-status.json",
-        "package-files.json"
+        "package-files.json",
+        "assets/manifest.json"
       ],
       "receiptRefs": []
     },
     {
       "disposition": "no_issue_found",
-      "id": "surface_synthetic-assets-repository-policy-and-canonical-prior-scan-artifacts",
-      "label": "Synthetic assets, repository policy, and canonical prior scan artifacts",
-      "notes": "Assets remain synthetic and hash-bound; prior scan artifacts are reviewed inputs and will be replaced by this exact-revision scan.",
+      "id": "surface_synthetic-assets-repository-policy-and-prior-scan-inputs",
+      "label": "Synthetic assets, repository policy, and prior scan inputs",
+      "notes": "Assets are synthetic and hash-bound; issue templates prohibit private reports; dependency policy is bounded; prior scan artifacts were treated only as historical input and will be replaced by this exact scan.",
       "paths": [
         ".github/FUNDING.yml",
         ".github/ISSUE_TEMPLATE/bug_report.md",
@@ -190,7 +172,6 @@
         "assets/doctor-light.png",
         "assets/logo.png",
         "assets/manifest.json",
-        "security/README.md",
         "security/scan/coverage.json",
         "security/scan/findings.json",
         "security/scan/scan-manifest.json"

--- a/security/scan/findings.json
+++ b/security/scan/findings.json
@@ -1,6 +1,6 @@
 {
   "documentType": "codex-security.findings",
   "findings": [],
-  "scanId": "7043a2c4-89b3-4bd4-9c8d-b48b851b83d9",
+  "scanId": "ecdc5ce0-c355-4292-a182-4c5d129e425c",
   "schemaVersion": "1.0"
 }

--- a/security/scan/scan-manifest.json
+++ b/security/scan/scan-manifest.json
@@ -5,21 +5,21 @@
       {
         "mediaType": "application/json",
         "path": "findings.json",
-        "sha256": "d3474ec90814569b522e534c617d23c7cc284331a7229ef3a0236fc454ef000c"
+        "sha256": "6aaa35b5f9dad4431bf3cc9bc8e1fee8030b3339d51b146346fb355ee6fd754e"
       },
       {
         "mediaType": "application/json",
         "path": "coverage.json",
-        "sha256": "2e37bc415e365994739566060837ec360f507574ccc35ce493a6d01437797b79"
+        "sha256": "f2a57174d4f7ba4808fb910b0e4db0298c78c5fca6cdb292930759ff26d8298b"
       }
     ],
-    "completedAt": "2026-08-27T16:39:04.881197Z",
+    "completedAt": "2026-08-27T20:07:05.771164Z",
     "coverageRef": "coverage.json",
     "findingsRef": "findings.json",
-    "id": "7043a2c4-89b3-4bd4-9c8d-b48b851b83d9",
+    "id": "ecdc5ce0-c355-4292-a182-4c5d129e425c",
     "preservedSources": {
-      "checkpoints/1915ec6878382d990325dfc0517a65594b403dbfecad98e3148e54dbd2d598f3.json": "1915ec6878382d990325dfc0517a65594b403dbfecad98e3148e54dbd2d598f3",
-      "checkpoints/a55a1d122eac8210eed19fc82901c61176a53bf4179ca3191c798490b12b3b51.json": "e7268fb65fb11be1b484d525734f901fcce7b28ed7709ff88f42654b180c16df"
+      "checkpoints/a9d82ef49abc17d548c2618d010166c57665782ba6fcc5b941b55f12ab63755c.json": "b64037199d7572be22a762b35eca96964b4cfae8c932f91f6045eaaf86b4df67",
+      "checkpoints/f109fd12fa41d25241518c8dd422c8380e4d91689255af7927a87e3dc9747c97.json": "f109fd12fa41d25241518c8dd422c8380e4d91689255af7927a87e3dc9747c97"
     },
     "producer": {
       "name": "codex-security-plugin",
@@ -110,68 +110,78 @@
         "tsconfig.json",
         "vitest.config.ts"
       ],
-      "context": "Full prior review plus exact delta review and successful release-gate/metadata reproduction.",
       "excludePaths": [],
       "includePaths": [
         "."
       ],
       "limitations": [
-        "Independent deep-scan variance reduction remained unavailable because the desktop parent lacked a managed filesystem permission profile.",
-        "No private live Messages or Contacts data was retained.",
-        "Future Apple schemas and provider behavior are outside this bounded evidence."
+        "Independent Deep Scan variance reduction was unavailable because the desktop parent lacks the required managed filesystem permission profile.",
+        "External provider protection and identity state remain publication-time controls.",
+        "No private Messages or Contacts values were retained."
       ],
-      "runtimeStatus": "complete",
-      "summary": "Complete standard review of exact signed beta.3 source 8b350f5b23b98422aca6743f771b7b720756d408 and all 82 tracked artifacts, revalidating the prior exact full-tree scan after one documentation-only correction.",
-      "validationMode": "Sequential parent review, exact documentation diff, prior full-tree source review, and executed release/metadata gates."
+      "runtimeStatus": "Node 24 full verification passed: 112 tests, seven tools over stdio and authenticated HTTP, installed tarball, clean-room redacted first run, exact metadata/package content, and zero npm advisories.",
+      "summary": "Complete Standard review of exact signed 2.0.0-rc.1 source 9c4a5b8e73f7ac7dd2f7ce20f1237ac689bcb12c and all 82 tracked artifacts.",
+      "validationMode": "Sequential exact-source parent review, independent static baseline, exact delta reconciliation, prior sealed scan as historical routing input only, and executed supported-runtime release gates."
     },
-    "sealedAt": "2026-08-27T16:39:04.881197Z",
-    "startedAt": "2026-08-27T16:38:03.084369Z",
+    "sealedAt": "2026-08-27T20:07:05.771164Z",
+    "startedAt": "2026-08-27T20:05:53.537904Z",
     "status": "completed",
     "target": {
       "displayName": "imessage-mcp",
       "kind": "git_revision",
-      "revision": "8b350f5b23b98422aca6743f771b7b720756d408",
+      "revision": "9c4a5b8e73f7ac7dd2f7ce20f1237ac689bcb12c",
       "targetId": "target_sha256_91a5cfb7b3d17e1fa8fb342de4bf5e1ed933375ae15ffb07b6229c2a5086c983"
     },
     "threatModel": {
       "assets": [
-        "Messages and lifecycle state",
-        "Contacts and handles",
-        "Conversation and attachment metadata",
-        "Database/WAL",
-        "Reference, lineage, and HTTP secrets",
-        "Release artifacts and provenance"
+        "Messages bodies and visible lifecycle state",
+        "Contacts, handles, group titles, URLs, attachment metadata and paths",
+        "Messages database, WAL, copied archives, schema and lineage",
+        "Launching client Full Disk Access and Contacts authorization",
+        "Reference, database identity, masking, and HTTP secrets plus authenticated cursors",
+        "Decoded bodies and memory-only search indexes",
+        "Privacy, diagnostic, and read-only guarantees",
+        "Signed source, scan evidence, package bytes, dependency lock, OIDC identities, Registry and release provenance"
       ],
       "assumptions": [
-        "Supported macOS and Node only",
-        "Operator protects launching client and 0600 files",
-        "Tailscale terminates TLS",
-        "Same-account arbitrary code execution is outside scope",
-        "Prompt guidance cannot control downstream processing"
+        "Supported macOS 14+ and Node 22, 24, or 26 only",
+        "Operator deliberately grants Full Disk Access to the launching client and protects 0600 secrets",
+        "Messages is the sole live writer; copied files and parent directory stay operator-controlled",
+        "Tailscale, GitHub environments, signer, OIDC, npm publisher, Registry, and immutability settings are external controls",
+        "Same-account arbitrary code execution and adversarial filesystem micro-races are outside the isolation claim",
+        "Prompt guidance cannot control downstream clients or providers",
+        "Fixtures and screenshots are synthetic; live parity retains no private values",
+        "Prior beta scan is historical input; this scan binds exact RC source"
       ],
       "attackerCapabilities": [
-        "Controls archival data",
-        "Sends malformed or oversized requests",
-        "Attempts unauthorized loopback access",
-        "Mutates local database state",
-        "Attempts package or provenance substitution"
+        "Authorized caller submits malformed or schema-valid requests",
+        "Unauthenticated local process probes loopback HTTP",
+        "Copied archive provider controls database-derived strings, blobs, relationships, paths, and sidecars",
+        "Archived participant places prompt-injection text, links, and commands in history fields",
+        "Contributor proposes source, workflow, manifest, or dependency changes without protected-provider authority",
+        "Downstream client or model provider controls processing and retention after disclosure"
       ],
       "securityObjectives": [
-        "Strict read-only operation",
-        "Privacy-ceiling enforcement",
-        "Archive data never treated as instruction",
-        "Fail-closed bounds and integrity",
-        "Authenticated bounded HTTP",
-        "Exact signed release lineage"
+        "Keep all seven 2.x tools strictly read-only",
+        "Prevent SQL, shell, deserialization, path-alias, cursor/reference, and cross-lineage attacks",
+        "Fail closed on unsupported schema, decoding, database changes, resource budgets, and provenance mismatches",
+        "Never relax the startup privacy ceiling and remove prohibited fields in stricter modes",
+        "Treat all archival strings as untrusted without claiming prompt-injection elimination",
+        "Authenticate HTTP before parsing and enforce loopback, authority, size, rate, concurrency, and deadline limits",
+        "Keep decoded search state memory-only and bounded",
+        "Bind publication to exact signed source, complete zero-finding scan, exact package/provenance agreement, and seven-day canary"
       ],
-      "summary": "Local read-only macOS MCP serving sensitive Messages history over stdio or authenticated loopback HTTP; risks include confidentiality, correctness, archival prompt injection, native decoding, database races, resource exhaustion, and release substitution.",
+      "summary": "At exact signed revision 9c4a5b8e73f7ac7dd2f7ce20f1237ac689bcb12c, imessage-mcp 2.0.0-rc.1 is a macOS-only seven-tool read-only MCP. The launching client supplies Full Disk Access and starts stdio or authenticated loopback HTTP. Bounded workers open a canonical live or copied Apple Messages SQLite database readonly with query_only; optional unified Contacts and a fixed Foundation/JXA decoder are local dependencies; decoded search state remains memory-only. Results cross a startup privacy ceiling before reaching the client, and all database-derived strings are untrusted archival data. Publication separately requires signed exact-source scan evidence, protected attestations, npm OIDC provenance, Registry agreement, immutable GitHub release, and a seven-day RC canary.",
       "trustBoundaries": [
-        "Apple databases to local process",
-        "Archived strings/blobs to decoder and results",
-        "Client requests to validation/privacy",
-        "Loopback HTTP to authentication/workers",
-        "0600 files to secret consumers",
-        "GitHub Actions to npm, Registry, and releases"
+        "Launching client to local stdio process",
+        "Authenticated caller to loopback HTTP before body parsing",
+        "CLI and environment into validated runtime configuration",
+        "Workers into canonical readonly Messages SQLite snapshots",
+        "Untrusted copied archive and sidecars into repositories",
+        "Workers into already-authorized unified Contacts",
+        "Workers into fixed bounded Foundation/JXA decoder",
+        "Internal result through privacy projection to MCP caller",
+        "Exact signed source through scan evidence and protected provider jobs"
       ]
     }
   },

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/anipotts/imessage-mcp",
     "source": "github"
   },
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-rc.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "imessage-mcp",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-rc.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -84,8 +84,12 @@ export async function doctor(config: RuntimeConfig, json: boolean): Promise<numb
     checks.push({ name: "wal_read", status: "pass", detail: "no active WAL is present" });
   }
   checks.push(schemaCheck);
-  const contacts = new UnifiedContactResolver(config.contacts_mode === "live").status();
-  checks.push({ name: "contacts", status: contacts.state === "available" ? "pass" : "warn", detail: contacts.state === "available" ? `${contacts.count} unified contacts available` : `continuing with handles: ${contacts.reason}` });
+  if (config.contacts_mode === "none") {
+    checks.push({ name: "contacts", status: "pass", detail: "disabled by --contacts none; using handles only" });
+  } else {
+    const contacts = new UnifiedContactResolver(true).status();
+    checks.push({ name: "contacts", status: contacts.state === "available" ? "pass" : "warn", detail: contacts.state === "available" ? `${contacts.count} unified contacts available` : `continuing with handles: ${contacts.reason}` });
+  }
   const decoder = new MessageTextDecoder();
   checks.push({ name: "decoder", status: await decoder.selfTest() ? "pass" : "fail", detail: decoder.healthState() === "healthy" ? "Foundation decoder self-test passed" : "Foundation decoder self-test failed" });
   checks.push({

--- a/tests/correctness.test.ts
+++ b/tests/correctness.test.ts
@@ -173,6 +173,11 @@ describe("2.0 data and query core", () => {
         status: "pass",
         detail: "active WAL is readable",
       });
+      expect(result.checks.find((check) => check.name === "contacts")).toEqual({
+        name: "contacts",
+        status: "pass",
+        detail: "disabled by --contacts none; using handles only",
+      });
     } finally {
       stdout.mockRestore();
       writer.close();


### PR DESCRIPTION
## Summary
- advance the verified 2.0 API from beta.3 to release candidate 1
- keep the seven-tool API and strict read-only runtime unchanged
- add privacy-first first-run, archival prompt-injection guidance, Full Disk Access and provider-processing boundaries, explicit Contacts behavior, collision-free client namespace, synthetic-only contribution guidance, and exact release-surface consistency gates
- improve handles-only doctor behavior and installed-package coverage
- seal the exact signed source with a complete 82-artifact security scan reporting zero findings

## Verification
- supported Node 24 full `npm run verify`: 112 tests, stdio and authenticated HTTP, installed tarball, clean-room redacted setup, metadata/package content, zero advisories
- million-message reference fixture remains within the documented performance and memory budgets
- exact source scan `ecdc5ce0-c355-4292-a182-4c5d129e425c` targets `9c4a5b8e73f7ac7dd2f7ce20f1237ac689bcb12c`
- signed evidence commit `01a57b761e9dd627dab8647a3cb0d4ea751206b5` changes only the three canonical scan files
- local sealed-evidence and package verification passed

Stable 2.0 remains blocked until the public RC completes the full seven-day canary.