### PR TITLE
test: mirror worker preparation in live parity

### DIFF
--- a/scripts/test-live-parity.ts
+++ b/scripts/test-live-parity.ts
@@ -77,6 +77,7 @@ async function exerciseLiveTools(): Promise<{
   referenceKey.fill(0);
   const runtime = new LocalToolRuntime(config, randomBytes(32));
   try {
+    await runtime.prepare();
     const probe = privateProbe();
     const durationMs: Record<string, number> = {};
     const call = async (tool: string, params: Record<string, unknown>) => {


### PR DESCRIPTION
## Summary

- prepare the local runtime before live parity tool timing
- match the production worker lifecycle exactly
- keep the RC tarball unchanged because this harness is not packaged

## Evidence

- `npm run verify` under Node 24/npm 11
- live parity: 375/375 exact bodies across iMessage, SMS/MMS, and RCS
- all seven tools passed with zero aggregate leakage and no private values emitted
- post-initialization `server_status`: 1 ms

The previous failure charged the one-time service discovery performed during worker initialization to the first metadata call. Production workers already await `runtime.prepare()` before accepting requests.