### PR TITLE
Pin release evidence to Codex Security 0.1.23

### DIFF
--- a/scripts/security-evidence.ts
+++ b/scripts/security-evidence.ts
@@ -15,7 +15,7 @@ const SCAN_PATHS = [
 const MAX_MANIFEST_BYTES = 16 * 1024 * 1024;
 const MAX_FINDINGS_BYTES = 128 * 1024 * 1024;
 const MAX_COVERAGE_BYTES = 32 * 1024 * 1024;
-const EXPECTED_SCAN_PRODUCER = "codex-security-plugin@0.1.22";
+const EXPECTED_SCAN_PRODUCER = "codex-security-plugin@0.1.23";
 
 interface SecurityEvidence {
   schema_version: 3;

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -278,7 +278,7 @@ describe("native and release hardening", () => {
         schemaVersion: "1.0",
         scan: {
           id: scanId,
-          producer: { name: "codex-security-plugin", version: "0.1.22" },
+          producer: { name: "codex-security-plugin", version: "0.1.23" },
           status: "completed",
           startedAt: "2026-08-11T00:00:00.000Z",
           completedAt: "2026-08-11T00:01:00.000Z",
@@ -321,6 +321,21 @@ describe("native and release hardening", () => {
       expect(evidence.subject.commit).toBe(evidenceCommit);
       expect(evidence.subject.scanned_commit).toBe(scanned);
       expect(evidence.security_scan).toMatchObject({ scan_revision: scanned, finding_count: 0, coverage: "complete" });
+
+      for (const producerVersion of ["0.1.22", "0.1.24"]) {
+        const rejectedManifest = JSON.parse(manifest);
+        rejectedManifest.scan.producer.version = producerVersion;
+        writeFileSync(path.join(scanDirectory, "scan-manifest.json"), JSON.stringify(rejectedManifest));
+        runGit("add", "security/scan/scan-manifest.json");
+        runGit("commit", "--amend", "--no-edit", "--quiet");
+        expect(() => execFileSync(tsx, [script, "create", "package.tgz", runGit("rev-parse", "HEAD"), "invalid.json"], {
+          cwd: directory,
+          stdio: "ignore",
+        })).toThrow();
+      }
+      writeFileSync(path.join(scanDirectory, "scan-manifest.json"), manifest);
+      runGit("add", "security/scan/scan-manifest.json");
+      runGit("commit", "--amend", "--no-edit", "--quiet");
 
       runGit("commit", "--allow-empty", "--quiet", "-m", "unscanned child");
       const unscanned = runGit("rev-parse", "HEAD");


### PR DESCRIPTION
The release gate rejected scans from the installed Codex Security version. Update its exact producer pin to 0.1.23 and add regression cases rejecting 0.1.22 and 0.1.24. Signature verification, direct-parent source binding, sealed artifact hashes, complete coverage, and zero findings remain required.

Validation: all 12 security tests passed on Node 24.19.0.