### PR TITLE
Reject inherited names at the runtime privacy boundary

### DIFF
--- a/scripts/test-installed.ts
+++ b/scripts/test-installed.ts
@@ -7,6 +7,8 @@ import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
 import { lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { runtimeConfig } from "../src/config.js";
 import { createFixture } from "../tests/fixture.js";
 import { runStdio } from "./test-protocol.js";
 import { assertPackedPackage } from "./package-manifest.js";
@@ -94,8 +96,43 @@ async function runCleanRoomFirstRequest(binary: string, fixture: ReturnType<type
     const output = JSON.stringify([status, conversations]);
     assert.doesNotMatch(output, /blob exact|thread reply|photo\.png|\+1555000000|unknown@example/u);
     assert.doesNotMatch(output, /T\d{2}:\d{2}:\d{2}/u);
+    for (const privacy_mode of ["__proto__", "constructor", "toString"]) {
+      const rejected = await client.callTool({ name: "list_conversations", arguments: { privacy_mode } });
+      assert.equal(rejected.isError, true);
+      assert.equal((rejected.structuredContent as { error: { reason: string } }).error.reason, "INVALID_INPUT");
+    }
   } finally {
     await client.close();
+  }
+}
+
+async function runInstalledRuntimePrivacy(installedRoot: string, fixture: ReturnType<typeof createFixture>): Promise<void> {
+  const { ToolRuntime } = await import(pathToFileURL(path.join(installedRoot, "dist", "index.js")).href) as typeof import("../src/index.js");
+  for (const privacy of ["redacted", "aggregate"] as const) {
+    const runtime = new ToolRuntime(runtimeConfig({
+      transport: "stdio", databasePath: fixture.databasePath, contacts: "none", privacy,
+      referenceKey: Buffer.alloc(32, 0x5a), databaseId: Buffer.alloc(32, 0x6b),
+    }));
+    try {
+      await runtime.initialize();
+      for (const [tool, params] of [
+        ["list_conversations", { limit: 10 }],
+        ["resolve_contact", { query: "+15550000001" }],
+      ] as const) {
+        for (const privacy_mode of ["__proto__", "constructor", "toString"]) {
+          const result = await runtime.call(tool, { ...params, privacy_mode });
+          assert.equal(result.isError, true);
+          assert.equal((result.structuredContent as { error: { reason: string } }).error.reason, "INVALID_INPUT");
+          assert.equal(result.structuredContent?.data, undefined);
+        }
+        const valid = await runtime.call(tool, params);
+        assert.equal(valid.isError, undefined);
+        assert.equal((valid.structuredContent?.effective_scope as { privacy_mode: string }).privacy_mode, privacy);
+        if (privacy === "aggregate") {
+          assert.doesNotMatch(JSON.stringify(valid), /Synthetic Group|conversation_ref|"contact":|T\d{2}:\d{2}:\d{2}/u);
+        }
+      }
+    } finally { await runtime.close(); }
   }
 }
 
@@ -201,6 +238,7 @@ async function main(): Promise<void> {
     });
     await runCleanRoomFirstRequest(binary, fixture, scratch);
     await runStdio(binary, [], fixture);
+    await runInstalledRuntimePrivacy(installedRoot, fixture);
 
     const clientConfig = {
       mcpServers: {
@@ -224,7 +262,7 @@ async function main(): Promise<void> {
     process.stdout.write(
       `installed tarball verification passed: ${installedNodes} dependency nodes, ` +
       `${(installedBytes / (1024 * 1024)).toFixed(1)} MiB, package contents, help, doctor, ` +
-      `clean-room redacted first run, stdio MCP handshake, and JSON config-shape check (no client apps launched)\n`,
+      `clean-room redacted first run, stdio MCP handshake, exported runtime privacy, and JSON config-shape check (no client apps launched)\n`,
     );
   } finally {
     fixture.cleanup();

--- a/src/privacy.ts
+++ b/src/privacy.ts
@@ -37,7 +37,7 @@ const IDENTITY_KEYS = new Set([
 
 export function effectivePrivacy(ceiling: PrivacyMode, requested?: PrivacyMode): PrivacyMode {
   const mode = requested ?? ceiling;
-  if (!(mode in LEVEL)) {
+  if (mode !== "full" && mode !== "redacted" && mode !== "aggregate") {
     throw new ImessageMcpError("INVALID_INPUT", "privacy mode must be full, redacted, or aggregate");
   }
   if (LEVEL[mode] < LEVEL[ceiling]) {

--- a/tests/privacy.test.ts
+++ b/tests/privacy.test.ts
@@ -30,6 +30,28 @@ describe("privacy ceilings", () => {
       .toThrowError(expect.objectContaining({ reason: "INVALID_INPUT" }));
   });
 
+  it("rejects inherited names and coerced privacy values before any projection", () => {
+    for (const ceiling of ["full", "redacted", "aggregate"] as const) {
+      for (const requested of [...Object.getOwnPropertyNames(Object.prototype), "", "Full", " aggregate ", ["full"], new String("full")]) {
+        expect(() => effectivePrivacy(ceiling, requested as "full"))
+          .toThrowError(expect.objectContaining({ reason: "INVALID_INPUT" }));
+      }
+    }
+  });
+
+  it("preserves default and stricter privacy requests", () => {
+    for (const ceiling of ["full", "redacted", "aggregate"] as const) {
+      expect(effectivePrivacy(ceiling)).toBe(ceiling);
+      expect(effectivePrivacy(ceiling, ceiling)).toBe(ceiling);
+      expect(effectivePrivacy(ceiling, "aggregate")).toBe("aggregate");
+    }
+    expect(effectivePrivacy("full", "redacted")).toBe("redacted");
+    expect(() => effectivePrivacy("aggregate", "redacted"))
+      .toThrowError(expect.objectContaining({ reason: "PRIVACY_RESTRICTED" }));
+    expect(() => effectivePrivacy("redacted", "full"))
+      .toThrowError(expect.objectContaining({ reason: "PRIVACY_RESTRICTED" }));
+  });
+
   it("keeps full fields only in full mode", () => {
     const result = successResult({ tool: "list_conversations", privacy: "full", maskingKey, effectiveScope: {}, data: privateData });
     expect(JSON.stringify(result.structuredContent)).toContain("private body");


### PR DESCRIPTION
Direct callers of the exported ToolRuntime API could pass an inherited property name as privacy_mode and receive conversation identities or exact timestamps above the configured disclosure ceiling. The shared validator now accepts only the three primitive mode values before comparing their levels. Registered MCP tools already rejected these inputs.

Validation: the new regression failed before the fix; the direct synthetic reproduction now returns INVALID_INPUT while valid aggregate calls still return counts. npm run verify passes all 120 tests, stdio and HTTP checks, freshly installed exported-runtime checks, metadata/package validation, and npm audit with zero findings. Independent patch review found no surviving bypass or regression.